### PR TITLE
Create Seeding SH Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project uses _Nx_ to manage the monorepo and npm as the package manager. To
 
 ### Environment Variables
 
-Navigate to `codewit.us/codewit/` and create a .env file with the following content:
+Navigate to `codewit.us/codewit/` and create a .env file with the following content (replace with your real values):
 
 ```sh
 # Frontend
@@ -21,6 +21,13 @@ GOOGLE_REDIRECT_URL="GOOGLE AUTH REDIRECT URL"
 GOOGLE_CLIENT_ID="YOUR CLIENT ID"
 GOOGLE_CLIENT_SECRET="YOUR SECRET"
 COOKIE_KEY="ANY ALPHANUMERICAL STRING"
+
+# Database
+DB_HOST=DB_HOST
+DB_USER=DB_USER
+DB_PASSWORD=DB_PASS
+DB_NAME=DB_NAME
+DB_PORT=PORT_NUM
 ```
 
 ### Running The Application

--- a/README.md
+++ b/README.md
@@ -48,23 +48,47 @@ From the [`codewit` directory, you can run nx commands](codewit/)
 
 ## Admin Seeding
 
-The codewit.us/codewit/api/src/scripts/seed-admins.ts file is used to seed the database with admin users. The script is run using the command `npm run seed-admins`.
+The `codewit.us/codewit/api/src/scripts/seed-admins.ts` file is used to seed the database with admin users. This can be done in two ways: manually using the `npm` command or with the provided `seed.sh` script, which not only handles environment variables but also provides options for both admin and data seeding.
 
-For example to seed an admin users with the emails abc@example.com and def@example.com, run the following command:
+### Method 1: Manual Seeding with `npm` Command
 
-```bash
+To manually seed admin users, ensure the required environment variables are set in a `.env` file or exported in your terminal. Here are the necessary variables:
+
+```sh
+DB_HOST=localhost
+DB_USER=codewitus_user
+DB_PASSWORD=12345
+DB_NAME=codewitus_db
+DB_PORT=5432
+```
+
+Once the environment variables are set, you can run the `npm` command directly. For example, to seed admin users with the emails `abc@example.com` and `def@example.com`, run:
+
+```sh
 npm run seed-admins -- --admin abc@example.com def@example.com
 ```
 
-do note that we also need to export the following environment variables for the seeding to work, for example:
+### Method 2: Using `seed.sh` Script with Automatic Environment Setup
+
+The `seed.sh` script automates environment variable setup, as well as admin and data seeding, making it easier to initialize the database. The script checks for required environment variables, setting any missing ones to default values, and provides options for various seeding needs.
+
+To seed emails as admins using `seed.sh` execute the following:
 
 ```sh
-export DB_HOST=localhost
-export DB_USER=codewitus_user
-export DB_PASSWORD=12345
-export DB_NAME=codewitus_db
-export DB_PORT=5432
+./seed.sh -e abc@example.com def@example.com
 ```
+To seed the database with general data, using a single emial for roster setup, run:
+
+```sh
+./seed.sh -d abc@example.com
+```
+
+To seed the database with both admin emails and general data (using the first email for data seeding), run:
+
+```sh
+./seed.sh -b abc@example.com def@example.com
+```
+For more details on all available options, you can use the -h flag to display the help information, which lists each command and provides usage examples.
 
 ## Contributing
 

--- a/codewit/api/project.json
+++ b/codewit/api/project.json
@@ -60,6 +60,30 @@
         "development": {}
       }
     },
+    "seed-db-builder": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "platform": "node",
+        "outputPath": "dist/api",
+        "format": ["cjs"],
+        "bundle": false,
+        "main": "api/src/scripts/seed-db.ts",
+        "tsConfig": "api/tsconfig.app.json",
+        "assets": ["api/src/assets"],
+        "generatePackageJson": true,
+        "esbuildOptions": {
+          "sourcemap": true,
+          "outExtension": {
+            ".js": ".js"
+          }
+        }
+      },
+      "configurations": {
+        "development": {}
+      }
+    },
     "serve": {
       "executor": "@nx/js:node",
       "defaultConfiguration": "development",

--- a/codewit/api/src/models/index.ts
+++ b/codewit/api/src/models/index.ts
@@ -9,6 +9,8 @@ import { Resource } from './resource';
 import { User } from './user';
 import { Attempt } from './attempt';
 
+require('dotenv').config();
+
 if (
   !process.env.DB_HOST ||
   !process.env.DB_NAME ||

--- a/codewit/api/src/scripts/seed-db.ts
+++ b/codewit/api/src/scripts/seed-db.ts
@@ -1,4 +1,4 @@
-import { User, Course, Demo, Exercise, Module, Resource, sequelize } from '../models';
+import { User, Course, Demo, Exercise, Module, Resource, Tag, Language, sequelize } from '../models';
 import { Command } from 'commander';
 
 const program = new Command();
@@ -12,11 +12,10 @@ const options = program.opts();
 const email = options.email || '';
 
 const seedData = async () => {
-
-  // See if the user exists
+  // see if the user exists
   let user = await User.findOne({ where: { email } });
 
-  // If the user does not exist, create them
+  // if the user does not exist, create them
   if (!user) {
     user = await User.create({
       email,
@@ -24,11 +23,99 @@ const seedData = async () => {
     });
   }
 
-  // Create General Data
+  const moduleTopics = [
+    'Variables', 'Objects', 'Decisions', 'Boolean Logic', 'While Loops',
+    'For Loops', 'Arrays', 'ArrayLists', '2D Arrays', 'Inheritance', 'Recursion'
+  ];
 
+  // create resources (we'll create one per module)
+  const resources = await Promise.all(moduleTopics.map(async (topic) => {
+    return await Resource.create({
+      url: `https://example.com/${topic.toLowerCase().replace(' ', '-')}`,
+      title: `${topic} Tutorial`,
+      source: 'Documentation'
+    });
+  }));
 
-}
+  // create modules with demos and exercises
+  const modules = await Promise.all(moduleTopics.map(async (topic, index) => {
+    // create 3 demos for each module
+    const demos = await Promise.all([1, 2, 3].map(async (num) => {
+      const demo = await Demo.create({
+        title: `${topic} Demo ${num}`,
+        youtube_id: 'XxBWL_ntnNE',
+        topic: topic,
+      });
 
+      // add tags to demo
+      await demo.addTag(
+        await Tag.findOrCreate({ 
+          where: { name: topic.toLowerCase() }
+        }).then(([tag]) => tag),
+        { through: { ordering: 1 } }
+      );
+
+      // create one exercise per demo
+      const exercise = await Exercise.create({
+        prompt: `Complete the ${topic} exercise ${num}`,
+        topic: topic,
+        referenceTest: 'test.assertEquals(solution(), expected);'
+      });
+
+      await demo.addExercise(exercise);
+
+      return demo;
+    }));
+
+    // create module and associate demos
+    const module = await Module.create({
+      topic: topic
+    });
+
+    // set language for module
+    const [language] = await Language.findOrCreate({
+      where: { name: 'cpp' }
+    });
+    await module.setLanguage(language);
+
+    // associate demos with module
+    await module.setDemos(demos);
+
+    // associate resource with module
+    await module.setResources([resources[index]]);
+
+    return module;
+  }));
+
+  // create the course
+  const course = await Course.create({
+    title: 'Open AP Computer Science',
+    id: 'ap-comp-sci'
+  });
+
+  // set course language
+  const [language] = await Language.findOrCreate({
+    where: { name: 'cpp' }
+  });
+  await course.setLanguage(language);
+
+  // add modules to course
+  await Promise.all(modules.map(async (module, idx) => {
+    await course.addModule(module, {
+      through: { ordering: idx + 1 }
+    });
+  }));
+
+  // add user as both instructor and roster member
+  await course.addInstructor(user);
+  await course.setRoster([user]);
+
+  console.log('Created course:', course.title);
+  console.log('Created modules:', moduleTopics.length);
+  console.log('Created demos:', moduleTopics.length * 3);
+  console.log('Created exercises:', moduleTopics.length * 3);
+  console.log('Created resources:', resources.length);
+};
 
 (async () => {
     if (options.force) {

--- a/codewit/api/src/scripts/seed-db.ts
+++ b/codewit/api/src/scripts/seed-db.ts
@@ -1,0 +1,42 @@
+import { User, Course, Demo, Exercise, Module, Resource, sequelize } from '../models';
+import { Command } from 'commander';
+
+const program = new Command();
+
+program
+  .version('1.0.0')
+  .option('-e, --email <email>', 'Create general data with the given email')
+  .parse(process.argv);
+
+const options = program.opts();
+const email = options.email || '';
+
+const seedData = async () => {
+
+  // See if the user exists
+  let user = await User.findOne({ where: { email } });
+
+  // If the user does not exist, create them
+  if (!user) {
+    user = await User.create({
+      email,
+      isAdmin: true,
+    });
+  }
+
+  // Create General Data
+
+
+}
+
+
+(async () => {
+    if (options.force) {
+      await sequelize.sync({ force: true });
+      console.log('Force syncing database');
+    }
+  
+    await seedData();
+    console.log('Database seeded!');
+  })();
+  

--- a/codewit/api/src/scripts/seed-db.ts
+++ b/codewit/api/src/scripts/seed-db.ts
@@ -44,6 +44,7 @@ const seedData = async () => {
       const demo = await Demo.create({
         title: `${topic} Demo ${num}`,
         youtube_id: 'XxBWL_ntnNE',
+        youtube_thumbnail: 'https://i.ytimg.com/vi/XxBWL_ntnNE/maxresdefault.jpg',
         topic: topic,
       });
 

--- a/codewit/client/src/components/nav/Nav.tsx
+++ b/codewit/client/src/components/nav/Nav.tsx
@@ -40,7 +40,7 @@ const NavBar = ({ email, admin, handleLogout }: { email: string, admin: boolean,
                 </button>
               </div>
             ) : (
-              <form action="http://localhost:3001/oauth2/google" method="post">
+              <form action="http://localhost:3001/oauth2/google" method="get">
                 <input
                   type="submit"
                   value="Log in with Google"
@@ -73,7 +73,7 @@ const NavBar = ({ email, admin, handleLogout }: { email: string, admin: boolean,
                   </button>
                 </div>
               ) : (
-                <form action="http://localhost:3001/oauth2/google" method="post" className="w-full">
+                <form action="http://localhost:3001/oauth2/google" method="get" className="w-full">
                   <input
                     type="submit"
                     value="Log in with Google"

--- a/codewit/package.json
+++ b/codewit/package.json
@@ -6,6 +6,7 @@
     "backend-dev": "nx run api:serve:development",
     "frontend-dev": "nx run client:serve:development --host 0.0.0.0 --port 3001",
     "seed-admins": "nx run api:seed-admins-builder && node dist/api/seed-admins.js",
+    "seed-data": "nx run api:seed-db-builder && node dist/api/seed-db.js",
     "seed-admins-force": "nx run api:seed-admins-builder && node dist/api/seed-admins.js --force"
   },
   "private": true,

--- a/codewit/seed.sh
+++ b/codewit/seed.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# Get Emails from Params
+EMAILS=$@
+DB_CONTAINER_NAME="codewitus_db"
+
+# Check if Docker database container is running
+function check_db {
+  if ! docker ps | grep -q "$DB_CONTAINER_NAME"; then
+    echo "Database container ($DB_CONTAINER_NAME) is not running."
+    exit 1
+  else
+    echo "Database container ($DB_CONTAINER_NAME) is running."
+  fi
+}
+
+# Seed database with emails
+function seed_emails {
+  if [ -z "$EMAILS" ]; then
+    echo "No emails provided to seed the database."
+    exit 1
+  fi
+  echo "Seeding database with emails: $EMAILS"
+  # TODO: SEED EMAILS INTO DATBASE (LIKELY JUST RUN THE NPM COMMAND)
+}
+
+# Seed database with data
+function seed_data {
+  echo "Seeding database with general data."
+  # TODO: SEED GENERAL DATA INTO DB (IDK YET)
+}
+
+# Display help information
+function display_help {
+  echo "Usage: $0 [options]"
+  echo ""
+  echo "Options:"
+  echo "  -e \"emails\"   Seed the database with the provided emails."
+  echo "  -d            Seed the database with general data."
+  echo "  -b \"emails\"   Seed the database with both emails and general data."
+  echo "  -h            Display this help message."
+  echo ""
+  echo "Examples:"
+  echo "  $0 -e \"email1@example.com email2@example.com\""
+  echo "      Seed only the database with emails."
+  echo "  $0 -d"
+  echo "      Seed only the database with general data."
+  echo "  $0 -b \"email1@example.com email2@example.com\""
+  echo "      Seed the database with both emails and general data."
+  exit 0
+}
+
+# Parse options
+SEED_EMAILS=false
+SEED_DATA=false
+
+if [ $# -eq 0 ]; then
+  echo "Invalid usage: No flags provided. Use -h for help."
+  exit 1
+fi
+
+while getopts "e:d:bh" option; do
+  case $option in
+    e)
+      SEED_EMAILS=true
+      EMAILS="$OPTARG"
+      ;;
+    d)
+      SEED_DATA=true
+      ;;
+    b)
+      SEED_EMAILS=true
+      SEED_DATA=true
+      EMAILS="$OPTARG"
+      ;;
+    h)
+      display_help
+      ;;
+    *)
+      echo "Invalid option. Use -h for help."
+      exit 1
+      ;;
+  esac
+done
+
+# Chekc if DB container is running & run the appropriate seeding functions
+if [ "$SEED_EMAILS" = true ]; then
+  check_db
+  seed_emails
+fi
+
+if [ "$SEED_DATA" = true ]; then
+  check_db
+  seed_data
+fi

--- a/codewit/seed.sh
+++ b/codewit/seed.sh
@@ -88,8 +88,16 @@ function seed_emails {
 
 # seed database with data
 function seed_data {
-  echo "Seeding database with general data."
-  # TODO: seed general data into db
+  # if -b flag is used, we only need the first email
+  if [ ${#EMAILS[@]} -lt 1 ]; then
+    echo "Data seeding requires at least one email for roster setup."
+    exit 1
+  fi
+
+  validate_emails
+
+  echo "Seeding database with general data and email: ${EMAILS[0]}"
+  # TODO: seed general data into db using the provided single email
 }
 
 # display help information
@@ -97,18 +105,18 @@ function display_help {
   echo "Usage: $0 [options]"
   echo ""
   echo "Options:"
-  echo "  -e \"emails\"   Seed the database with the provided emails."
-  echo "  -d             Seed the database with general data."
-  echo "  -b \"emails\"   Seed the database with both emails and general data."
-  echo "  -h             Display this help message."
+  echo "  -e \"email(s)\"   Seed the database with the provided emails."
+  echo "  -d \"email\"      Seed the database with general data. Requires exactly one email."
+  echo "  -b \"email(s)\"   Seed the database with both emails and general data, using the first email for data."
+  echo "  -h              Display this help message."
   echo ""
   echo "Examples:"
   echo "  $0 -e email1@example.com email2@example.com"
   echo "      Seed only the database with emails."
-  echo "  $0 -d"
-  echo "      Seed only the database with general data."
+  echo "  $0 -d email@example.com"
+  echo "      Seed only the database with general data, using the provided email."
   echo "  $0 -b email1@example.com email2@example.com"
-  echo "      Seed the database with both emails and general data."
+  echo "      Seed the database with both emails and general data, using the first email for data."
   exit 0
 }
 
@@ -143,7 +151,7 @@ function main {
         exit 1
         ;;
       :)
-        echo "WARNING: Invalid used of -$OPTARG. Use -h for help."
+        echo "WARNING: Invalid usage of -$OPTARG. Use -h for help."
         exit 1
         ;;
     esac
@@ -153,7 +161,7 @@ function main {
   shift $((OPTIND - 1))
 
   # capture remaining arguments as additional emails if -e or -b is specified
-  if [ "$SEED_EMAILS" = true ]; then
+  if [ "$SEED_EMAILS" = true ] || [ "$SEED_DATA" = true ]; then
     EMAILS+=("$@")
   fi
 
@@ -171,6 +179,8 @@ function main {
     fi
     
     if [ "$SEED_DATA" = true ]; then
+      # Use only the first email if -b flag is active
+      EMAILS=("${EMAILS[0]}")
       seed_data
     fi
   fi

--- a/codewit/seed.sh
+++ b/codewit/seed.sh
@@ -1,12 +1,57 @@
 #!/bin/bash
 
-# Get Emails from Params
-EMAILS=$@
+# get emails from params
 DB_CONTAINER_NAME="codewitus_db"
+EMAILS=()
+EMAIL_REGEX='^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
 
-# Check if Docker database container is running
+# check and set environment variables in .env if they are missing
+function check_env_vars {
+  echo -e "\nChecking and setting environment variables in .env..."
+
+  # define required variables and defaults
+  REQUIRED_VARS=("DB_HOST" "DB_USER" "DB_PASSWORD" "DB_NAME" "DB_PORT")
+  DEFAULT_VALUES=("localhost" "codewitus_user" "12345" "codewitus_db" "5432")
+
+  # create .env file if it doesn't exist
+  [ ! -f .env ] && touch .env
+
+  # check if any required variables are missing
+  MISSING_VARS=false
+  for i in "${!REQUIRED_VARS[@]}"; do
+    VAR_NAME=${REQUIRED_VARS[$i]}
+    if ! grep -q "^$VAR_NAME=" .env; then
+      MISSING_VARS=true
+      break
+    fi
+  done
+
+  # prompt the user if any variables are missing
+  if $MISSING_VARS; then
+    echo "One or more required environment variables are missing."
+    read -p "Would you like to use the default values for all missing variables? (y/n): " choice
+    if [ "$choice" = "y" ]; then
+      for i in "${!REQUIRED_VARS[@]}"; do
+        VAR_NAME=${REQUIRED_VARS[$i]}
+        DEFAULT_VALUE=${DEFAULT_VALUES[$i]}
+        if ! grep -q "^$VAR_NAME=" .env; then
+          echo -e "\n$VAR_NAME=$DEFAULT_VALUE" >> .env
+          echo "$VAR_NAME set to $DEFAULT_VALUE in .env"
+        fi
+      done
+    else
+      echo "Please set the missing environment variables manually."
+      exit 1
+    fi
+  else
+    echo "All required environment variables are already set in .env."
+  fi
+}
+
+# check if docker database container is running
 function check_db {
-  if ! docker ps | grep -q "$DB_CONTAINER_NAME"; then
+  echo -e "\nChecking if database container ($DB_CONTAINER_NAME) is running..."
+  if ! docker ps | grep "$DB_CONTAINER_NAME" > /dev/null 2>&1; then
     echo "Database container ($DB_CONTAINER_NAME) is not running."
     exit 1
   else
@@ -14,82 +59,121 @@ function check_db {
   fi
 }
 
-# Seed database with emails
+# validate email format
+function validate_emails {
+  echo -e "\nValidating email(s)..."
+  for email in "${EMAILS[@]}"; do
+    if [[ ! $email =~ $EMAIL_REGEX ]]; then
+      echo "Invalid email format: $email"
+      exit 1
+    fi
+  done
+  echo -e "All emails are valid.\n"
+}
+
+# seed database with emails
 function seed_emails {
-  if [ -z "$EMAILS" ]; then
-    echo "No emails provided to seed the database."
+  if [ ${#EMAILS[@]} -eq 0 ]; then
+    echo "No email(s) provided to seed the database."
     exit 1
   fi
-  echo "Seeding database with emails: $EMAILS"
-  # TODO: SEED EMAILS INTO DATBASE (LIKELY JUST RUN THE NPM COMMAND)
+
+  validate_emails
+  
+  echo "Seeding database with email(s): ${EMAILS[*]}"
+  
+  # run the npm command with .env for the seed-admins script
+  npm run seed-admins -- --admin "${EMAILS[*]}"
 }
 
-# Seed database with data
+# seed database with data
 function seed_data {
   echo "Seeding database with general data."
-  # TODO: SEED GENERAL DATA INTO DB (IDK YET)
+  # TODO: seed general data into db
 }
 
-# Display help information
+# display help information
 function display_help {
   echo "Usage: $0 [options]"
   echo ""
   echo "Options:"
   echo "  -e \"emails\"   Seed the database with the provided emails."
-  echo "  -d            Seed the database with general data."
+  echo "  -d             Seed the database with general data."
   echo "  -b \"emails\"   Seed the database with both emails and general data."
-  echo "  -h            Display this help message."
+  echo "  -h             Display this help message."
   echo ""
   echo "Examples:"
-  echo "  $0 -e \"email1@example.com email2@example.com\""
+  echo "  $0 -e email1@example.com email2@example.com"
   echo "      Seed only the database with emails."
   echo "  $0 -d"
   echo "      Seed only the database with general data."
-  echo "  $0 -b \"email1@example.com email2@example.com\""
+  echo "  $0 -b email1@example.com email2@example.com"
   echo "      Seed the database with both emails and general data."
   exit 0
 }
 
-# Parse options
-SEED_EMAILS=false
-SEED_DATA=false
+function main {
+  # parse options
+  SEED_EMAILS=false
+  SEED_DATA=false
 
-if [ $# -eq 0 ]; then
-  echo "Invalid usage: No flags provided. Use -h for help."
-  exit 1
-fi
+  if [ $# -eq 0 ]; then
+    echo "Invalid usage: No flags provided. Use -h for help."
+    exit 1
+  fi
 
-while getopts "e:d:bh" option; do
-  case $option in
-    e)
-      SEED_EMAILS=true
-      EMAILS="$OPTARG"
-      ;;
-    d)
-      SEED_DATA=true
-      ;;
-    b)
-      SEED_EMAILS=true
-      SEED_DATA=true
-      EMAILS="$OPTARG"
-      ;;
-    h)
-      display_help
-      ;;
-    *)
-      echo "Invalid option. Use -h for help."
-      exit 1
-      ;;
-  esac
-done
+  while getopts ":e:dbh" option; do
+    case $option in
+      e)
+        SEED_EMAILS=true
+        EMAILS+=("$OPTARG")
+        ;;
+      d)
+        SEED_DATA=true
+        ;;
+      b)
+        SEED_EMAILS=true
+        SEED_DATA=true
+        ;;
+      h)
+        display_help
+        ;;
+      \?)
+        echo "Invalid option. Use -h for help."
+        exit 1
+        ;;
+      :)
+        echo "WARNING: Invalid used of -$OPTARG. Use -h for help."
+        exit 1
+        ;;
+    esac
+  done
 
-# Chekc if DB container is running & run the appropriate seeding functions
-if [ "$SEED_EMAILS" = true ]; then
-  check_db
-  seed_emails
-fi
+  # shift the parsed options to get the remaining positional arguments
+  shift $((OPTIND - 1))
 
-if [ "$SEED_DATA" = true ]; then
-  check_db
-  seed_data
-fi
+  # capture remaining arguments as additional emails if -e or -b is specified
+  if [ "$SEED_EMAILS" = true ]; then
+    EMAILS+=("$@")
+  fi
+
+  # check environment variables
+  check_env_vars
+
+  # check if we need to seed emails, data, or both
+  if [ "$SEED_EMAILS" = true ] || [ "$SEED_DATA" = true ]; then
+    # check if the database container is running only once
+    check_db
+    
+    # run the appropriate seeding functions
+    if [ "$SEED_EMAILS" = true ]; then
+      seed_emails
+    fi
+    
+    if [ "$SEED_DATA" = true ]; then
+      seed_data
+    fi
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
**index.ts**
- added `require('dotenv').config();` so that it looks for the database variables from a .env file instead

**seed.sh**
- a script to simplify admin user seeding with flexible options and automated environment variable configuration. 

  **features:**
  1. **Admin/Data Seeding Options:**
     - `-e "emails"`: Seed the database with specified admin emails.
     - `-d`: Seed the database with general data.
     - `-b "emails"`: Seed with both emails and general data.
     - `-h`: Display a help message for usage.
  
  2. **Environment Variable Configuration:**
     - Checks if required database variables (`DB_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`, `DB_PORT`) are set in `.env`.
     - Prompts to add missing variables with default values, reducing setup time.

  Updates end seeding data that looks like this:
  
  ![image](https://github.com/user-attachments/assets/ac796da5-a80f-4ea1-9684-4b35b59339fe)