### PR TITLE
Add optional -p port flag to avoid Postgres conflicts on localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ To seed emails as admins using `seed.sh` execute the following:
 ```sh
 ./seed.sh -e abc@example.com def@example.com
 ```
+
 To seed the database with general data, using a single emial for roster setup, run:
 
 ```sh
@@ -95,6 +96,7 @@ If your machine already has a local Postgres instance running on the default por
 
 ```sh
 ./seed.sh -p 5440 -e abc@example.com
+```
 
 For more details on all available options, you can use the -h flag to display the help information, which lists each command and provides usage examples.
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ To seed the database with both admin emails and general data (using the first em
 ```sh
 ./seed.sh -b abc@example.com def@example.com
 ```
+
+#### Optional: Use a Custom Postgres Port
+
+If your machine already has a local Postgres instance running on the default port (`5432`), you can specify a different port when running the seed script using the `-p` flag:
+
+```sh
+./seed.sh -p 5440 -e abc@example.com
+
 For more details on all available options, you can use the -h flag to display the help information, which lists each command and provides usage examples.
 
 ## Contributing

--- a/codewit/docker-compose.yml
+++ b/codewit/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   codewitus_db:
     image: postgres:16-bookworm
     ports:
-      - 5432:5432
+      - "${PG_HOST_PORT:-5432}:5432"
     environment:
       - POSTGRES_PASSWORD=12345
       - POSTGRES_USER=codewitus_user

--- a/codewit/seed.sh
+++ b/codewit/seed.sh
@@ -9,7 +9,7 @@ EMAILS=()
 EMAIL_REGEX='^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
 
 # Custom port to change from default 5432 in case user already has PostgreSQL instance running on that port
-CUSTOM_PORT=""
+CUSTOM_DB_PORT=""
 
 # check and set environment variables in .env if they are missing
 function check_env_vars {
@@ -108,11 +108,9 @@ function seed_emails {
 
   # run the npm command with .env for the seed-admins script
 
-  if [ -n "$CUSTOM_PORT" ]; then
-    echo "Running with custom port" 
-    DB_PORT="$CUSTOM_PORT" npm run seed-admins -- --admin "${EMAILS[*]}"
+  if [ -n "$CUSTOM_DB_PORT" ]; then
+    DB_PORT="$CUSTOM_DB_PORT" npm run seed-admins -- --admin "${EMAILS[*]}"
   else
-    echo "Running without custom port"
     npm run seed-admins -- --admin "${EMAILS[*]}"
   fi
 }
@@ -131,11 +129,9 @@ function seed_data {
   echo -e "Seeding database with general data and email: \n 🌱: ${EMAILS[0]}"
   # TODO: seed general data into db using the provided single email
     
-  if [ -n "$CUSTOM_PORT" ]; then
-    echo "Running with custom port" 
-    DB_PORT="$CUSTOM_PORT" npm run seed-data -- --email "${EMAILS[0]}"
+  if [ -n "$CUSTOM_DB_PORT" ]; then
+    DB_PORT="$CUSTOM_DB_PORT" npm run seed-data -- --email "${EMAILS[0]}"
   else
-    echo "Running without custom port"
     npm run seed-data -- --email "${EMAILS[0]}"
   fi
 }
@@ -174,7 +170,7 @@ function main {
   while getopts ":e:dbh:p:" option; do
     case $option in
       p)
-        CUSTOM_PORT="$OPTARG"
+        CUSTOM_DB_PORT="$OPTARG"
         ;;
       e)
         SEED_EMAILS=true
@@ -209,8 +205,8 @@ function main {
     EMAILS+=("$@")
   fi
 
-  if [ -n "$CUSTOM_PORT" ]; then
-    export PG_HOST_PORT="$CUSTOM_PORT"
+  if [ -n "$CUSTOM_DB_PORT" ]; then
+    export PG_HOST_PORT="$CUSTOM_DB_PORT"
     echo " Using custom Postgres host port: $PG_HOST_PORT"
   fi
 

--- a/codewit/seed.sh
+++ b/codewit/seed.sh
@@ -8,6 +8,9 @@ BE_CONTAINER_NAME="codewit-app"
 EMAILS=()
 EMAIL_REGEX='^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
 
+# Custom port to change from default 5432 in case user already has PostgreSQL instance running on that port
+CUSTOM_PORT=""
+
 # check and set environment variables in .env if they are missing
 function check_env_vars {
   echo -e "\nChecking and setting environment variables in .env..."
@@ -104,8 +107,16 @@ function seed_emails {
   done  
 
   # run the npm command with .env for the seed-admins script
-  npm run seed-admins -- --admin "${EMAILS[*]}"
+
+  if [ -n "$CUSTOM_PORT" ]; then
+    echo "Running with custom port" 
+    DB_PORT="$CUSTOM_PORT" npm run seed-admins -- --admin "${EMAILS[*]}"
+  else
+    echo "Running without custom port"
+    npm run seed-admins -- --admin "${EMAILS[*]}"
+  fi
 }
+
 
 # seed database with data
 function seed_data {
@@ -119,7 +130,14 @@ function seed_data {
 
   echo -e "Seeding database with general data and email: \n 🌱: ${EMAILS[0]}"
   # TODO: seed general data into db using the provided single email
-  npm run seed-data -- --email "${EMAILS[0]}"
+    
+  if [ -n "$CUSTOM_PORT" ]; then
+    echo "Running with custom port" 
+    DB_PORT="$CUSTOM_PORT" npm run seed-data -- --email "${EMAILS[0]}"
+  else
+    echo "Running without custom port"
+    npm run seed-data -- --email "${EMAILS[0]}"
+  fi
 }
 
 # display help information
@@ -130,7 +148,8 @@ function display_help {
   echo "  -e \"email(s)\"   Seed the database with the provided emails."
   echo "  -d \"email\"      Seed the database with general data. Requires exactly one email."
   echo "  -b \"email(s)\"   Seed the database with both emails and general data, using the first email for data."
-  echo "  -h              Display this help message."
+  echo "  -p PORT           Override DB_PORT just for this run (default: 5432)."
+  echo "  -h                Display this help message."
   echo ""
   echo "Examples:"
   echo "  $0 -e email1@example.com email2@example.com"
@@ -152,8 +171,11 @@ function main {
     exit 1
   fi
 
-  while getopts ":e:dbh" option; do
+  while getopts ":e:dbh:p:" option; do
     case $option in
+      p)
+        CUSTOM_PORT="$OPTARG"
+        ;;
       e)
         SEED_EMAILS=true
         EMAILS+=("$OPTARG")
@@ -185,6 +207,11 @@ function main {
   # capture remaining arguments as additional emails if -e or -b is specified
   if [ "$SEED_EMAILS" = true ] || [ "$SEED_DATA" = true ]; then
     EMAILS+=("$@")
+  fi
+
+  if [ -n "$CUSTOM_PORT" ]; then
+    export PG_HOST_PORT="$CUSTOM_PORT"
+    echo " Using custom Postgres host port: $PG_HOST_PORT"
   fi
 
   # check environment variables


### PR DESCRIPTION
This PR adds support for an optional -p flag to seed.sh, allowing developers to specify a custom Postgres port. This is helpful in environments where port 5432 is already occupied (e.g., when Postgres is running locally).

Changes
	•	docker-compose.yml uses ${PG_HOST_PORT:-5432} to allow overriding the default port.
	•	seed.sh now checks for the -p flag and uses it when connecting to the database.

Why

Some contributors may already be running a local instance of Postgres on 5432. This change avoids port conflicts and allows docker compose up and seed.sh to run smoothly by specifying an alternate port like 5440.