### PR TITLE
removed `nxCloudAccessToken` #64

### DIFF
--- a/codewit/nx.json
+++ b/codewit/nx.json
@@ -17,7 +17,7 @@
     ],
     "sharedGlobals": []
   },
-  "nxCloudAccessToken": "NDhlMzMxMTMtNWM0MS00N2VhLTg4MGEtYmNkOTY4ZWRhYzRmfHJlYWQtd3JpdGU=",
+  "neverConnectToCloud": true,
   "plugins": [
     {
       "plugin": "@nx/vite/plugin",


### PR DESCRIPTION
removed the `nxCloudAccessToken` from the `nx.json` as we are not using their cloud services. also added in the `neverConnectToCloud` to prevent (hopefully) anything trying to connect to their services.