### PR TITLE
Ensure full visibility of dropdowns in modal forms

### DIFF
--- a/codewit/client/src/components/form/ExerciseSelect.tsx
+++ b/codewit/client/src/components/form/ExerciseSelect.tsx
@@ -68,6 +68,9 @@ const ExerciseSelect = ({ onSelectExercises, initialExercises }: ExerciseSelectP
         options={exercises}
         className="text-sm bg-blue text-white border-none w-full rounded-lg"
         styles={SelectStyles}
+        menuPortalTarget={document.body}
+        menuPosition="fixed"
+        menuPlacement="auto"  
       />
     </div>
   );

--- a/codewit/client/src/components/form/LanguageSelect.tsx
+++ b/codewit/client/src/components/form/LanguageSelect.tsx
@@ -29,6 +29,10 @@ const LanguageSelect = ({handleChange, initialLanguage }: LanguageSelectProps) =
       value={options.find(option => option.value === initialLanguage) || options[0]}
       isSearchable={false}
       styles={SelectStyles}
+      menuPortalTarget={document.body}
+      menuPosition="fixed"
+      menuPlacement="auto"
+      menuShouldScrollIntoView={false}
     />
   </div>
 );

--- a/codewit/client/src/components/form/ReusableModal.tsx
+++ b/codewit/client/src/components/form/ReusableModal.tsx
@@ -29,8 +29,7 @@ const ReusableModal: React.FC<ReusableModalProps> = ({
         </Modal.Header>
 
         <Modal.Body
-          className="p-6 bg-gray-800 space-y-6 overflow-y-auto"
-          style={{ maxHeight: "70vh" }} 
+          className="p-6 bg-gray-800 space-y-6 overflow-visible"
         >
           {children}
         </Modal.Body>

--- a/codewit/client/src/components/form/VideoSelect.tsx
+++ b/codewit/client/src/components/form/VideoSelect.tsx
@@ -65,6 +65,9 @@ const VideoSelect = ({ onSelectVideo, selectedVideoId }: VideoSelectProps): JSX.
           options={videos}
           className="text-sm bg-blue text-white border-none w-full rounded-lg"
           styles={SelectStyles}
+          menuPortalTarget={document.body}
+          menuPosition="fixed"
+          menuPlacement="auto"
         />
       )}
     </div>

--- a/codewit/client/src/pages/Create.tsx
+++ b/codewit/client/src/pages/Create.tsx
@@ -37,7 +37,7 @@ const Create = (): JSX.Element => {
           </Link>
         </div>
       </div>
-      <div className="flex-1 h-full overflow-y-auto bg-foreground-800">
+      <div className="flex-1 h-full overflow-visible bg-foreground-800">
         <Outlet />
       </div>
     </div>

--- a/codewit/client/src/utils/styles.ts
+++ b/codewit/client/src/utils/styles.ts
@@ -16,6 +16,9 @@ const styles = {
   menu: (provided: any) => ({
     ...provided,
     backgroundColor: 'rgb(55, 65, 81)',
+    maxHeight: '300px',
+    overflowY: 'auto',
+    zIndex: 9999,
   }),
   option: (provided: any, state: any) => ({
     ...provided,
@@ -53,6 +56,10 @@ const styles = {
   input: (provided: any) => ({
     ...provided,
     color: 'white',
+  }),
+  menuPortal: (base: any) => ({
+    ...base,
+    zIndex: 9999
   }),
 };
 


### PR DESCRIPTION
Addresses an issue where dropdown menus like Select Exercises and Select YouTube Video were being cut off within modals 
due to overflow and stacking context problems.

Changes include:
	•	Updates to SelectStyles to explicitly set menuPortalTarget to document.body and menuPosition: 'fixed'
	•	Adjusted container/modal styles to allow dropdown menus to render correctly
	•	Verified that dropdowns are now scrollable and fully visible
	
Tested on:
	•	All modal forms under the Create page tabs: _(Module, Course, Demo, Exercise, Resource)_
	•	Verified dropdowns render fully and are scrollable where needed
	•	Rebuilt frontend and app images to ensure a clean rebuild with no stale Docker cache