### PR TITLE
course enrolling / auto_enroll & registrations #80

### DIFF
--- a/codewit/api/src/models/course.ts
+++ b/codewit/api/src/models/course.ts
@@ -21,17 +21,21 @@ class Course extends Model<
 > {
   declare id: string;
   declare title: string;
+  declare enrolling: boolean;
+  declare auto_enroll: boolean;
 
   declare language?: NonAttribute<Language>;
   declare modules?: NonAttribute<Module[]>;
   declare instructors?: NonAttribute<User[]>;
   declare roster?: NonAttribute<User[]>;
+  declare registered?: NonAttribute<User[]>;
 
   declare static associations: {
     language: Association<Course, Language>;
     modules: Association<Course, Module>;
     instructors: Association<Course, User>;
     roster: Association<Course, User>;
+    registered: Association<Course, User>;
   };
 
   declare setLanguage: BelongsToSetAssociationMixin<Language, number>;
@@ -56,6 +60,16 @@ class Course extends Model<
           type: DataTypes.STRING,
           allowNull: false,
         },
+        enrolling: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+          defaultValue: false,
+        },
+        auto_enroll: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+          defaultValue: false,
+        }
       },
       {
         sequelize,

--- a/codewit/api/src/models/course_registration.ts
+++ b/codewit/api/src/models/course_registration.ts
@@ -1,0 +1,45 @@
+import {
+  Model,
+  DataTypes,
+  Sequelize,
+  InferAttributes,
+  InferCreationAttributes,
+} from "sequelize";
+
+import { User } from "./user";
+import { Course } from "./course";
+
+export class CourseRegistration extends Model<
+  InferAttributes<CourseRegistration>,
+  InferCreationAttributes<CourseRegistration>
+> {
+  declare courseId: string;
+  declare userUid: number;
+
+  static initialize(sequelize: Sequelize) {
+    this.init(
+      {
+        courseId: {
+          type: DataTypes.STRING,
+          primaryKey: true,
+          references: {
+            model: "courses",
+            key: "id",
+          },
+        },
+        userUid: {
+          type: DataTypes.INTEGER,
+          primaryKey: true,
+          references: {
+            model: "users",
+            key: "uid"
+          }
+        }
+      },
+      {
+        sequelize,
+        modelName: "course_registration",
+      }
+    );
+  }
+}

--- a/codewit/api/src/models/index.ts
+++ b/codewit/api/src/models/index.ts
@@ -4,6 +4,7 @@ import { Exercise } from './exercise';
 import { Tag } from './tag';
 import { Language } from './language';
 import { Course } from './course';
+import { CourseRegistration } from "./course_registration";
 import { Module } from './module';
 import { Resource } from './resource';
 import { User } from './user';
@@ -45,13 +46,14 @@ const sequelize = new Sequelize({
   Resource,
   Module,
   Course,
+  CourseRegistration,
   User,
   Attempt,
   UserDemoCompletion,
   UserExerciseCompletion,
   UserModuleCompletion,
   DemoExercises,
-  ModuleDemos
+  ModuleDemos,
 ].forEach((model) => model.initialize(sequelize));
 
 Demo.belongsToMany(Exercise, { through: DemoExercises });
@@ -116,6 +118,9 @@ User.belongsToMany(Course, {
 
 Course.belongsToMany(User, { through: 'CourseRoster', as: 'roster' });
 User.belongsToMany(Course, { through: 'CourseRoster', as: 'studentCourses' });
+
+Course.belongsToMany(User, { through: CourseRegistration, as: "registered"});
+User.belongsToMany(Course, { through: CourseRegistration, as: "registered"});
 
 Demo.belongsToMany(User, { through: 'DemoLikes', as: 'likedBy' });
 User.belongsToMany(Demo, { through: 'DemoLikes', as: 'likedDemos' });

--- a/codewit/api/src/routes/course.ts
+++ b/codewit/api/src/routes/course.ts
@@ -69,6 +69,8 @@ courseRouter.post('/', checkAdmin, async (req, res) => {
 
     const course = await createCourse(
       validatedBody.data.title,
+      validatedBody.data.enrolling,
+      validatedBody.data.auto_enroll,
       validatedBody.data.language,
       validatedBody.data.modules,
       validatedBody.data.instructors,
@@ -94,6 +96,8 @@ courseRouter.patch('/:uid', checkAdmin, async (req, res) => {
     const course = await updateCourse(
       req.params.uid,
       validatedBody.data.title,
+      validatedBody.data.enrolling,
+      validatedBody.data.auto_enroll,
       validatedBody.data.language,
       validatedBody.data.modules,
       validatedBody.data.instructors,

--- a/codewit/api/src/typings/response.types.ts
+++ b/codewit/api/src/typings/response.types.ts
@@ -26,6 +26,8 @@ export interface ExerciseResponse {
 export interface CourseResponse {
     id: string;
     title: string;
+    enrolling: boolean,
+    auto_enroll: boolean,
     language: string;
     modules: ModuleResponse[] | number[];
     roster: UserResponse[];

--- a/codewit/api/src/utils/responseFormatter.ts
+++ b/codewit/api/src/utils/responseFormatter.ts
@@ -76,6 +76,8 @@ function formatSingleCourse(course: Course, isGetStudent = false): CourseRespons
   return {
     id: course.id,
     title: course.title,
+    enrolling: course.enrolling,
+    auto_enroll: course.auto_enroll,
     language: course.language.name,
     modules: isGetStudent
       ? course.modules.map((module) => filterModule(module) as ModuleResponse)

--- a/codewit/client/src/pages/CourseForm.tsx
+++ b/codewit/client/src/pages/CourseForm.tsx
@@ -19,8 +19,9 @@ import {
 import { useFetchModules } from "../hooks/useModule";
 import { useFetchUsers } from "../hooks/useUsers";
 import { isFormValid } from "../utils/formValidationUtils";
+import { cn } from "../utils/styles";
 
-const CourseForm = (): JSX.Element => {
+export default function CourseForm() {
   const { data: courses, setData: setCourses } = useFetchCourses();
   const { data: modules } = useFetchModules();
   const { data: users } = useFetchUsers();
@@ -35,6 +36,8 @@ const CourseForm = (): JSX.Element => {
   const [formData, setFormData] = useState<Course>({
     id: "",
     title: "",
+    enrolling: false,
+    auto_enroll: false,
     language: "cpp",
     modules: [],
     instructors: [],
@@ -45,7 +48,6 @@ const CourseForm = (): JSX.Element => {
   const [userOptions, setUserOptions] = useState<SelectedTag[]>([]);
 
   useEffect(() => {
-
     setModuleOptions(
       modules.map((module: any) => ({
         value: module.uid,
@@ -97,8 +99,8 @@ const CourseForm = (): JSX.Element => {
     try {
       const payload = {
         ...formData,
-        instructors: formData.instructors.map((uid) => ( uid)), 
-        roster: formData.roster.map((uid) => (uid)), 
+        instructors: formData.instructors.map((uid) => ( uid)),
+        roster: formData.roster.map((uid) => (uid)),
       };
 
       if (isEditing) {
@@ -195,12 +197,51 @@ const CourseForm = (): JSX.Element => {
               required
             />
           </div>
-
+          <div className="flex flex-row gap-4">
+            <div className="flex flex-row items-center gap-2">
+              <input
+                id="enrolling"
+                type="checkbox"
+                name="enrolling"
+                checked={formData.enrolling}
+                onChange={e => {
+                  setFormData(v => ({
+                    ...v,
+                    enrolling: e.target.checked,
+                    auto_enroll: !e.target.checked ? false : v.auto_enroll,
+                  }));
+                }}
+              />
+              <label
+                htmlFor="enrolling"
+                title={"allows user to request being registered for a course"}
+              >
+                Enrolling
+              </label>
+            </div>
+            <div className={cn("flex flex-row items-center gap-2", {"cursor-not-allowed": !formData.enrolling})}>
+              <input
+                id="auto_enroll"
+                type="checkbox"
+                name="auto_enroll"
+                className={cn({"cursor-not-allowed": !formData.enrolling})}
+                disabled={!formData.enrolling}
+                checked={formData.auto_enroll}
+                onChange={e => handleInputChange("auto_enroll", e.target.checked)}
+              />
+              <label
+                htmlFor="auto_enroll"
+                title={"allows for any user to be automatically enrolled into the course. \"enrolling\" must be enabled"}
+                className={cn({"cursor-not-allowed": !formData.enrolling})}
+              >
+                Auto Enroll
+              </label>
+            </div>
+          </div>
           <LanguageSelect
             handleChange={(e) => handleInputChange("language", e.target.value)}
             initialLanguage={formData.language}
           />
-
           <div data-testid="module-select">
             <InputLabel htmlFor="modules">Modules</InputLabel>
             <Select
@@ -243,6 +284,4 @@ const CourseForm = (): JSX.Element => {
       </ReusableModal>
     </div>
   );
-};
-
-export default CourseForm;
+}

--- a/codewit/client/src/pages/CourseForm.tsx
+++ b/codewit/client/src/pages/CourseForm.tsx
@@ -124,6 +124,8 @@ export default function CourseForm() {
     setFormData({
       id: "",
       title: "",
+      enrolling: false,
+      auto_enroll: false,
       language: "cpp",
       modules: [],
       instructors: [],

--- a/codewit/client/src/utils/styles.ts
+++ b/codewit/client/src/utils/styles.ts
@@ -1,3 +1,6 @@
+import { clsx, ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
 // codewit/client/src/utils/styles.ts
 const styles = {
   control: (provided: any) => ({
@@ -64,3 +67,7 @@ const styles = {
 };
 
 export {styles as SelectStyles};
+
+export function cn(...inputs: ClassValue[]) {
+    return twMerge(clsx(inputs))
+}

--- a/codewit/lib/shared/interfaces/src/lib/interfaces.ts
+++ b/codewit/lib/shared/interfaces/src/lib/interfaces.ts
@@ -47,7 +47,7 @@ interface DemoPostResponse {
 interface Tag {
   value: any;
   uid?: number;
-  name: string; 
+  name: string;
   createdAt?: string;
   updatedAt?: string;
 }
@@ -90,6 +90,8 @@ interface Resource {
 interface Course {
   id: string;
   title: string;
+  enrolling: boolean,
+  auto_enroll: boolean,
   language: string;
   modules: Module[];
   instructors: Array<{
@@ -152,8 +154,8 @@ interface Thumbnail {
   height: number;
 }
 
-export type { 
-  Exercise, 
+export type {
+  Exercise,
   ExerciseResponse,
   ExerciseFormData,
   Demo,
@@ -162,7 +164,7 @@ export type {
   DemoPostResponse,
   DemoResponse,
   DemoFormData,
-  YouTubeSearchResult, 
+  YouTubeSearchResult,
   Thumbnail,
   Resource,
   Course,

--- a/codewit/lib/shared/validations/src/lib/course.ts
+++ b/codewit/lib/shared/validations/src/lib/course.ts
@@ -1,15 +1,19 @@
 import { z } from 'zod';
 
-const createCourseSchema = z.object({
+export const createCourseSchema = z.object({
   title: z.string(),
+  enrolling: z.boolean().default(false),
+  auto_enroll: z.boolean().default(false),
   language: z.string().optional(),
   modules: z.number().array().optional(),
   roster: z.number().array().optional(),
   instructors: z.number().array().optional(),
 });
 
-const updateCourseSchema = z.object({
+export const updateCourseSchema = z.object({
   title: z.string().optional(),
+  enrolling: z.boolean().optional(),
+  auto_enroll: z.boolean().optional(),
   language: z.string().optional(),
   modules: z.number().array().optional(),
   roster: z.number().array().optional(),
@@ -18,5 +22,3 @@ const updateCourseSchema = z.object({
 
 export type ZCreateCourseSchema = z.infer<typeof createCourseSchema>;
 export type ZUpdateCourseSchema = z.infer<typeof updateCourseSchema>;
-
-export { createCourseSchema, updateCourseSchema };

--- a/codewit/package-lock.json
+++ b/codewit/package-lock.json
@@ -15,6 +15,7 @@
         "@types/express-session": "^1.18.0",
         "@uiw/react-markdown-editor": "^6.0.0",
         "axios": "^1.6.0",
+        "clsx": "^2.1.1",
         "commander": "^12.0.0",
         "connect-redis": "^8.0.0",
         "express": "~4.18.1",
@@ -35,6 +36,7 @@
         "redis": "^4.7.0",
         "remark-gfm": "^4.0.0",
         "sequelize": "^6.36.0",
+        "tailwind-merge": "^2.6.0",
         "tslib": "^2.3.0",
         "unique-names-generator": "^4.7.1",
         "zod": "^3.22.4",
@@ -11246,6 +11248,16 @@
         "tailwindcss": "^3"
       }
     },
+    "node_modules/flowbite-react/node_modules/tailwind-merge": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.4.0.tgz",
+      "integrity": "sha512-49AwoOQNKdqKPd9CViyH5wJoSKsCDjUlzL8DxuGp3P1FsGY36NJDAa18jLZcaHAUUuTj+JB8IAo8zWgBNvBF7A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.5",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
@@ -18492,9 +18504,9 @@
       "license": "MIT"
     },
     "node_modules/tailwind-merge": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.4.0.tgz",
-      "integrity": "sha512-49AwoOQNKdqKPd9CViyH5wJoSKsCDjUlzL8DxuGp3P1FsGY36NJDAa18jLZcaHAUUuTj+JB8IAo8zWgBNvBF7A==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
+      "integrity": "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/codewit/package.json
+++ b/codewit/package.json
@@ -8,8 +8,8 @@
     "seed-admins": "nx run api:seed-admins-builder && node dist/api/seed-admins.js",
     "seed-data": "nx run api:seed-db-builder && node dist/api/seed-db.js",
     "seed-admins-force": "nx run api:seed-admins-builder && node dist/api/seed-admins.js --force",
-    "test:gui": "cd client-e2e && npx cypress open", 
-    "test": "cd client-e2e && npx cypress run" 
+    "test:gui": "cd client-e2e && npx cypress open",
+    "test": "cd client-e2e && npx cypress run"
   },
   "private": true,
   "dependencies": {
@@ -19,6 +19,7 @@
     "@types/express-session": "^1.18.0",
     "@uiw/react-markdown-editor": "^6.0.0",
     "axios": "^1.6.0",
+    "clsx": "^2.1.1",
     "commander": "^12.0.0",
     "connect-redis": "^8.0.0",
     "express": "~4.18.1",
@@ -39,6 +40,7 @@
     "redis": "^4.7.0",
     "remark-gfm": "^4.0.0",
     "sequelize": "^6.36.0",
+    "tailwind-merge": "^2.6.0",
     "tslib": "^2.3.0",
     "unique-names-generator": "^4.7.1",
     "zod": "^3.22.4",


### PR DESCRIPTION
added 2 new fields to a course to allow specifying if it is currently allowing enrollments and if it will auto enroll users upon request. a new mapping table has also been added that will contain a list of new registrations for a course. currently the admin page is not setup to display the list of registrations for a course. one will be added but for now this will only allow toggling the enrolling / auto_enroll fields.

fixes #80 