### PR TITLE
Language now displayed in exercises, fixes #85

### DIFF
--- a/codewit/client/src/pages/ExerciseForm.tsx
+++ b/codewit/client/src/pages/ExerciseForm.tsx
@@ -162,7 +162,7 @@ const ExerciseForms = (): JSX.Element => {
   const columns = [
     { header: "Prompt", accessor: "prompt" },
     { header: "Topic", accessor: "topic" },
-    { header: "Language", accessor: "language.name" },
+    { header: "Language", accessor: "language" },
   ];
 
   return (


### PR DESCRIPTION
This PR fixes the “Language” column in Create → Exercise so that the actual language value (e.g., java, python, cpp) is displayed instead of a placeholder dash.

### Before

<img width="943" height="828" alt="image" src="https://github.com/user-attachments/assets/9bdd2a9a-eae8-4d40-9c8e-85d6b2e64b8a" />


### After

<img width="1278" height="866" alt="image" src="https://github.com/user-attachments/assets/68e1bb33-69c0-475d-af55-a802814296d3" />
