### PR TITLE
Show Module Topic instead of raw UID in Course form

### DIFF
--- a/codewit/client/src/pages/CourseForm.tsx
+++ b/codewit/client/src/pages/CourseForm.tsx
@@ -51,7 +51,7 @@ export default function CourseForm() {
     setModuleOptions(
       modules.map((module: any) => ({
         value: module.uid,
-        label: module.title || module.uid,
+        label: module.topic || module.uid,
       }))
     );
 


### PR DESCRIPTION
### What changed
* **File:** `client/src/pages/CourseForm.tsx`
* Updated module-picker label from `module.title || module.uid`  
  to `module.topic || module.uid` so the dropdown shows the
  human-readable topic instead of the numeric UID.

### Why
* **Better UX** – instructors/admins can recognise modules instantly.
* **Consistency** – matches everywhere else we surface `topic`.

### Before
<img width="984" height="726" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/8fb4640c-5bbb-473e-86b8-86c716143fcc" />

### After
<img width="1213" height="810" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/027c4f4f-3d30-40ce-bc78-86028b726e9b" />
