### PR TITLE
student registration #81

### DIFF
--- a/codewit/api/src/controllers/course.ts
+++ b/codewit/api/src/controllers/course.ts
@@ -4,6 +4,7 @@ import {
   colors,
   animals,
 } from 'unique-names-generator';
+import { Transaction } from "sequelize";
 import { StudentCourse } from "@codewit/interfaces";
 
 import {
@@ -282,7 +283,7 @@ async function getStudentCoursesByUid(userUid: number): Promise<CourseResponse[]
   return formatCourseResponse(courses, true);
 }
 
-export async function getStudentCourse(course_id: string): Promise<StudentCourse | null> {
+export async function getStudentCourse(course_id: string, transaction?: Transaction): Promise<StudentCourse | null> {
   const course = await Course.findOne({
     where: { id: course_id },
     include: [
@@ -303,6 +304,7 @@ export async function getStudentCourse(course_id: string): Promise<StudentCourse
       { association: Course.associations.instructors },
     ],
     order: [[Course.associations.modules, CourseModules, 'ordering', 'ASC']],
+    transaction,
   });
 
   if (course == null) {

--- a/codewit/api/src/models/index.ts
+++ b/codewit/api/src/models/index.ts
@@ -164,6 +164,7 @@ export {
   Module,
   ModuleDemos,
   CourseModules,
+  CourseRegistration,
   Resource,
   User,
   Attempt,

--- a/codewit/client/src/components/placeholders.tsx
+++ b/codewit/client/src/components/placeholders.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from "react";
+
+interface CenterPrompt {
+  header: string | ReactNode,
+  children?: ReactNode,
+}
+
+export function CenterPrompt({header, children}: CenterPrompt) {
+  let header_node = typeof header === "string" ?
+      <h2 className="text-2xl text-white">{header}</h2> :
+      header;
+
+  return <div className="h-container-full max-w-full flex items-center justify-center bg-zinc-900">
+    <div className="w-1/2 flex flex-col flex-nowrap items-center bg-foreground-500 rounded-2xl p-4">
+      {header_node}
+      {children}
+    </div>
+  </div>;
+}

--- a/codewit/client/src/pages/CourseView.tsx
+++ b/codewit/client/src/pages/CourseView.tsx
@@ -1,44 +1,79 @@
-import { useState, useEffect } from 'react';
-import { useParams, useLocation } from "react-router-dom";
-import {
-  PlayIcon,
-  ChevronRightIcon,
-  ChevronDownIcon,
-} from '@heroicons/react/24/solid';
+import axios, { AxiosError } from "axios";
+import { Modal } from "flowbite-react";
+import { useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
 
-import { StudentCourse as StuCourse, TeacherCourse as TeachCourse} from '@codewit/interfaces';
-import { Accordion } from '@codewit/shared/components';
+import { StudentCourse as StuCourse} from '@codewit/interfaces';
 
-import Error from '../components/error/Error';
-import Loading from '../components/loading/LoadingPage';
+import { default as ErrorView } from "../components/error/Error";
+import Loading from "../components/loading/LoadingPage";
 import { useAxiosFetch } from "../hooks/fetching";
 
 import StudentView from "./course/StudentView";
-import TeacherView from './course/TeacherView';
-
-import bulbLit from '/bulb(lit).svg';
-import bulbUnlit from '/bulb(unlit).svg';
-import { useAuth } from '../hooks/useAuth';
+import { CenterPrompt } from "../components/placeholders";
 
 interface StudentCourse extends StuCourse {
   type: "StudentView",
 }
 
-type GetCourse = StudentCourse;
+interface Enrolling {
+  type: "Enrolling",
+  title: string,
+  is_registered: boolean,
+  auto_enroll: boolean,
+}
+
+// on the chance that an instructor goes to this page and will only receive the
+// instructor data they should be redirected to the dashboard instead. this could
+// change in the future if the instructor wanted to view the course without having
+// to be actually enrolled in the course.
+interface TeacherView {
+  type: "TeacherView",
+  title: string,
+}
+
+type GetCourse = StudentCourse | TeacherView | Enrolling;
+
+interface AlreadyEnrolled {
+  type: "AlreadyEnrolled",
+}
+
+interface AlreadyRegistered {
+  type: "AlreadyRegistered",
+}
+
+interface Enrolled extends StuCourse {
+  type: "Enrolled",
+}
+
+interface Registered {
+  type: "Registered",
+}
+
+type RegistrationResult = AlreadyEnrolled | AlreadyRegistered | Enrolled | Registered;
 
 interface CourseView {
   onCourseChange: (title: string) => void,
 }
 
 export default function CourseView({onCourseChange}: CourseView) {
-  
-  const { course_id: courseId } = useParams();
+  const { course_id } = useParams();
+  const navigate = useNavigate();
 
-  const { data: course, loading, error } = useAxiosFetch<GetCourse | null>(`/api/courses/${courseId}?student_view=1`, null);
+  if (course_id == null) {
+    throw new Error("course_id not provided");
+  }
+
+  const [refresh, set_refresh] = useState(0);
+  const { data: course, loading, error, setData } = useAxiosFetch<GetCourse | null>(`/api/courses/${course_id}?student_view=1&r=${refresh}`, null);
 
   useEffect(() => {
     if (course != null) {
-      onCourseChange(course.title);
+      if (course.type === "StudentView") {
+        onCourseChange(course.title);
+      } else {
+        onCourseChange("");
+      }
     } else {
       onCourseChange("");
     }
@@ -49,13 +84,230 @@ export default function CourseView({onCourseChange}: CourseView) {
   }
 
   if (error || course == null) {
-    return <Error message="Failed to fetch courses. Please try again later." />;
+    return <ErrorView message="Failed to fetch courses. Please try again later."/>;
+  }
+
+  if (course.type === "TeacherView") {
+    navigate(`/${course_id}/dashboard`);
+
+    return <Loading/>;
   }
 
   switch (course.type) {
     case "StudentView":
-      return <StudentView course={course}/>
+      return <StudentView course={course}/>;
+    case "Enrolling":
+      if (course.is_registered) {
+        return <CenterPrompt header={course.title}>
+          <p className="text-center text-white">
+            You have requested enrollment for this course. Wait for the instructor to admit you.
+          </p>
+          <Link to="/" className="text-white bg-accent-500 rounded-md mt-4 p-2">
+            Home page
+          </Link>
+        </CenterPrompt>;
+      } else {
+        return <EnrollingView
+          course_id={course_id}
+          course_title={course.title}
+          auto_enroll={course.auto_enroll}
+          on_update={data => {
+            switch (data.type) {
+              case "AlreadyEnrolled":
+                set_refresh(v => v + 1);
+                break;
+              case "AlreadyRegistered":
+              case "Registered":
+                setData({
+                  type: "Enrolling",
+                  title: course.title,
+                  is_registered: true,
+                  auto_enroll: course.auto_enroll
+                });
+                break;
+              case "Enrolled":
+                setData({...data, type: "StudentView"});
+                break;
+            }
+          }}
+        />;
+      }
     default:
-      return <div>Unknown View from server</div>;
+      return <CenterPrompt header={"Unknown Response"}>
+        <p className="text-center text-white">
+          The client does not know how to handle the response from the server. Sorry, try going back to the home page.
+        </p>
+        <Link to="/" className="text-white bg-accent-500 rounded-md mt-4 p-2">
+          Home page
+        </Link>
+      </CenterPrompt>;
   }
+}
+
+interface EnrollingViewProps {
+  course_id: string,
+  course_title: string,
+  auto_enroll: boolean,
+  on_update: (data: RegistrationResult) => void,
+}
+
+interface RegError {
+  title: string,
+  message: string,
+}
+
+function EnrollingView({course_id, course_title, auto_enroll, on_update}: EnrollingViewProps) {
+  let [sending, set_sending] = useState(false);
+  let [reg_state, set_reg_state] = useState<RegistrationResult | null>({type: "Registered"});
+  let [error, set_error] = useState<RegError | null>({title: "test", message: "test"});
+
+  async function request_enrollment() {
+    if (sending) {
+      return;
+    }
+
+    set_sending(true);
+
+    try {
+      let result = await axios.post<RegistrationResult>(`/api/courses/${course_id}/register`);
+
+      set_reg_state(result.data);
+    } catch (err) {
+      if (err instanceof AxiosError) {
+        if (err.response != null) {
+          switch (err.response.data.error) {
+            case "CourseNotFound":
+              set_error({
+                title: "Course Not Found",
+                message: "The requested course was not found. Make sure that the course you are registering for exists and is accepting enrollments."
+              });
+              break;
+            case "ServerError":
+              set_error({
+                title: "Server Error",
+                message: "There was a server error when registering for this course. Try again and see if the problem persists.",
+              });
+              break;
+            default:
+              console.error("unhandled error type:", err.response.data.error);
+
+              set_error({
+                title: "Server Error",
+                message: "There was a server error when registering for this course. Try again and see if the problem persists.",
+              });
+              break;
+          }
+        } else {
+          console.error("request error:", err);
+
+          set_error({
+            title: "Request Error",
+            message: "There was a problem sending the registration request. Try again and see if the error persists."
+          });
+        }
+      } else {
+        console.error("error when sending registration:", err);
+
+        set_error({
+          title: "Client Error",
+          message: "There was a problem registering for this course. Try again and see if the error persists."
+        });
+      }
+    }
+
+    set_sending(false);
+  }
+
+  let modal_title = null;
+  let modal_contents = null;
+
+  if (reg_state != null) {
+    switch (reg_state.type) {
+      case "AlreadyEnrolled":
+        modal_title = "Already Enrolled";
+        modal_contents = "You are already enrolled in this course.";
+        break;
+      case "AlreadyRegistered":
+        modal_title = "Already Registered";
+        modal_contents = "You have already registered for this course.";
+        break;
+      case "Enrolled":
+        modal_title = "Enrolled";
+        modal_contents = "You are now enrolled in this course.";
+        break;
+      case "Registered":
+        modal_title = "Registered";
+        modal_contents = "You have registered for this course.";
+        break;
+    }
+  }
+
+  return <>
+    <CenterPrompt header={course_title}>
+      <p className="text-center text-white">
+        {auto_enroll ?
+          "This course is currently auto-enrolling students. Would you like to enroll for this course?"
+          :
+          "This course is currently enrolling students. Would you like to enroll for this course?"
+        }
+      </p>
+      <div className="flex flex-row gap-x-4 items-center">
+        {sending ?
+          <div className="text-white bg-accent-700 rounded-md mt-4 p-2">
+            Home Page
+          </div>
+          :
+          <Link to="/" className="text-white bg-accent-500 rounded-md mt-4 p-2">
+            Home page
+          </Link>
+        }
+        <button
+          type="button"
+          className="text-white bg-green-400 rounded-md mt-4 p-2"
+          disabled={sending}
+          onClick={() => request_enrollment()}
+        >
+          {auto_enroll ? "Auto Enroll" : "Request Enrollment"}
+        </button>
+      </div>
+    </CenterPrompt>
+    <Modal
+      show={reg_state != null}
+      position="center"
+      onClose={() => {
+        if (reg_state != null) {
+          on_update(reg_state);
+        }
+
+        set_reg_state(null);
+      }}
+    >
+      <Modal.Header className="bg-foreground-500 border-b border-foreground-700 rounded-t-md p-2">
+        {modal_title}
+      </Modal.Header>
+      <Modal.Body className="bg-foreground-500 rounded-b-md">
+        {modal_contents}
+      </Modal.Body>
+    </Modal>
+    <Modal
+      show={error != null}
+      position="center"
+      onClose={() => {
+        set_error(null);
+      }}
+    >
+      <Modal.Header className="bg-foreground-500 border-b border-foreground-700 rounded-t-md p-2">
+        {error?.title}
+      </Modal.Header>
+      <Modal.Body className="bg-foreground-500 rounded-b-md">
+        {error?.message}
+      </Modal.Body>
+    </Modal>
+  </>;
+}
+
+// this is placeholder in order to force tailwind to include the styling
+// needed. see ./tailwind.config.js for further details.
+function E() {
+  return <div className="md:h-auto text-xl"></div>
 }

--- a/codewit/client/src/pages/CourseView.tsx
+++ b/codewit/client/src/pages/CourseView.tsx
@@ -158,8 +158,8 @@ interface RegError {
 
 function EnrollingView({course_id, course_title, auto_enroll, on_update}: EnrollingViewProps) {
   let [sending, set_sending] = useState(false);
-  let [reg_state, set_reg_state] = useState<RegistrationResult | null>({type: "Registered"});
-  let [error, set_error] = useState<RegError | null>({title: "test", message: "test"});
+  let [reg_state, set_reg_state] = useState<RegistrationResult | null>(null);
+  let [error, set_error] = useState<RegError | null>(null);
 
   async function request_enrollment() {
     if (sending) {

--- a/codewit/client/tailwind.config.js
+++ b/codewit/client/tailwind.config.js
@@ -12,10 +12,18 @@ module.exports = {
     ),
     // Add shared library components to content
     join(__dirname, '../lib/shared/components/**/*.{ts,tsx}'),
-    flowbite.content(),
+    // similar to below, the path that this outputs is expecting a directory
+    // structure that does not exist for this project. the path that
+    // `flowbite.content()` gives will not be found unless it is modified or
+    // the location of this file changes
+    //flowbite.content(),
     ...createGlobPatternsForDependencies(__dirname),
     './src/**/*.{js,jsx,ts,tsx}',
-    '../../node_modules/flowbite-react/lib/**/*.js',
+    // the previous path did not properly include the tailwindcss from flowbite
+    // and because of that the proper styling was not included for the
+    // components. because of this if it is properly included parse of the site
+    // are no longer properly styled.
+    //"../node_modules/flowbite-react/dist/{esm,cjs}/**/*.{mjs,cjs}",
   ],
   theme: {
     screens: {


### PR DESCRIPTION
this adds in the ability for a student to go to a course and auto enroll or register for a course. the course must be allowing enrollment and for the auto_enroll the course must also be allowing that. the styling of the page is fairly straight forward and modeled after other parts of the site. errors are handled for the registration portion and if the student is auto enrolled then they will receive course information once enrolled so they do not have to reload the page.

closes #81 

this also includes some notes about the styling issues for the `flowbite-react` components we are using. I did not make any changes to that as it will affect other parts of the site and is not related to this change.