### PR TITLE
gitignore compose override

### DIFF
--- a/codewit/.gitignore
+++ b/codewit/.gitignore
@@ -41,3 +41,8 @@ testem.log
 Thumbs.db
 
 .nx/cache
+
+compose.override.yaml
+compose.override.yml
+docker-compose.override.yaml
+docker-compose.override.yml


### PR DESCRIPTION
added in gitignore entries for ignoring compose override files so they will not be constantly showing in the changes.