### PR TITLE
exercise ordering #105

### DIFF
--- a/codewit/api/src/migrations/20250801114001-exercise-order.js
+++ b/codewit/api/src/migrations/20250801114001-exercise-order.js
@@ -1,0 +1,45 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    up: (queryInterface, Sequelize) => queryInterface.sequelize.transaction(async transaction => {
+        await queryInterface.addColumn(
+            "DemoExercises",
+            "order",
+            {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+                defaultValue: 0,
+            },
+            {
+                transaction
+            }
+        );
+
+        await queryInterface.sequelize.query(
+            `
+            with tmp_table as (
+                select "demoUid" as demo_uid,
+                    "exerciseUid" as exercise_uid,
+                    row_number() over (partition by "demoUid" order by "demoUid", "exerciseUid") - 1 as new_order
+                from "DemoExercises"
+            )
+            update "DemoExercises"
+            set "order" = tmp_table.new_order
+            from tmp_table
+            where "DemoExercises"."demoUid" = tmp_table.demo_uid and
+                "DemoExercises"."exerciseUid" = tmp_table.exercise_uid`,
+            {
+                type: Sequelize.QueryTypes.RAW,
+                transaction,
+            }
+        );
+    }),
+    down: (queryInterface, Sequelize) => queryInterface.sequelize.transaction(async transaction => {
+        await queryInterface.removeColumn(
+            "DemoExercises",
+            "order",
+            {
+                transaction
+            }
+        );
+    }),
+};

--- a/codewit/api/src/models/demoExercises.ts
+++ b/codewit/api/src/models/demoExercises.ts
@@ -12,6 +12,7 @@ class DemoExercises extends Model<
 > {
   declare demoUid: number;
   declare exerciseUid: number;
+  declare order: number;
 
   static initialize(sequelize: Sequelize) {
     this.init(
@@ -26,13 +27,18 @@ class DemoExercises extends Model<
           primaryKey: true,
           references: { model: 'exercises', key: 'uid' },
         },
+        order: {
+          type: DataTypes.INTEGER,
+          allowNull: false,
+          defaultValue: 0,
+        },
       },
       {
         sequelize,
         modelName: 'DemoExercises',
         tableName: 'DemoExercises',
         timestamps: true,
-      }
+      },
     );
   }
 }

--- a/codewit/api/src/typings/response.types.ts
+++ b/codewit/api/src/typings/response.types.ts
@@ -62,7 +62,12 @@ export interface DemoResponse {
     language: string,
     youtube_id: string,
     youtube_thumbnail: string,
-    exercises: number[]
+    exercises: DemoExercise[]
+}
+
+export interface DemoExercise {
+    uid: number,
+    prompt: string,
 }
 
 export interface AttemptWithEval {

--- a/codewit/api/src/utils/responseFormatter.ts
+++ b/codewit/api/src/utils/responseFormatter.ts
@@ -99,7 +99,7 @@ export function formatSingleDemo(
     language: demo.language.name,
     youtube_id: demo.youtube_id,
     youtube_thumbnail: demo.youtube_thumbnail,
-    exercises: demo.exercises ? demo.exercises.map(each => each.uid) : [],
+    exercises: demo.exercises ? demo.exercises.map(({uid, prompt}) => ({uid, prompt})) : [],
   }
 }
 

--- a/codewit/client/src/components/form/LanguageSelect.tsx
+++ b/codewit/client/src/components/form/LanguageSelect.tsx
@@ -7,11 +7,20 @@ interface LanguageSelectProps {
   initialLanguage: string;
 }
 
-const options = [
+interface LanguageOption {
+  value: string,
+  label: string,
+}
+
+export const language_options: LanguageOption[] = [
   { value: 'cpp', label: 'C++' },
   { value: 'java', label: 'Java' },
   { value: 'python', label: 'Python' },
 ];
+
+export function get_language_option(given: string): LanguageOption {
+  return language_options.find(opt => given === opt.value) ?? language_options[0];
+}
 
 const LanguageSelect = ({handleChange, initialLanguage }: LanguageSelectProps) => (
   <div 
@@ -24,9 +33,9 @@ const LanguageSelect = ({handleChange, initialLanguage }: LanguageSelectProps) =
     <Select
       id="language"
       name="language"
-      options={options}
+      options={language_options}
       onChange={option => handleChange({ target: { value: option?.value || '', name: "language"}} as any)}
-      value={options.find(option => option.value === initialLanguage) || options[0]}
+      value={language_options.find(option => option.value === initialLanguage) || language_options[0]}
       isSearchable={false}
       styles={SelectStyles}
       menuPortalTarget={document.body}

--- a/codewit/client/src/components/form/TagSelect.tsx
+++ b/codewit/client/src/components/form/TagSelect.tsx
@@ -1,7 +1,6 @@
 // codewit/client/src/components/form/TagSelect.tsx
 import CreatableSelect from 'react-select/creatable';
 import Select, { SingleValue } from 'react-select';
-import { useState, useEffect } from 'react';
 import { topicTree } from '@codewit/topics';
 import { SelectStyles } from '../../utils/styles.js';
 import { MultiValue } from 'react-select';
@@ -21,57 +20,55 @@ interface TagSelectProps {
   isMulti?: boolean;
 }
 
+function extract_topics_rec(node: TopicNode, list: Tag[]) {
+  for (let key of Object.keys(node)) {
+    list.push({value: key, label: key});
+
+    if (typeof node[key] === "object") {
+      extract_topics_rec(node[key], list);
+    }
+  }
+}
+
+function extract_topics(): Tag[] {
+  let rtn: Tag[] = [];
+
+  extract_topics_rec(topicTree, rtn);
+
+  return rtn;
+}
+
+export const topic_options = extract_topics();
+
 const TagSelect = ({ setSelectedTags, selectedTags, isMulti = true }: TagSelectProps): JSX.Element => {
-  const [tags, setTags] = useState<Tag[]>([]);
-
-  useEffect(() => {
-    const extractTags = (obj: TopicNode): Tag[] => {
-      return Object.keys(obj).flatMap(key => {
-        const currentTag = { value: key, label: key };
-        if (typeof obj[key] === 'object' && Object.keys(obj[key]).length) {
-          return [currentTag, ...extractTags(obj[key])];
-        }
-        return currentTag;
-      });
-    };
-
-    setTags(extractTags(topicTree));
-
-  }, []);
-
   const handleChange = (newValue: MultiValue<Tag> | SingleValue<Tag>)  => {
     setSelectedTags(newValue as Tag[] | Tag);
   };
 
-
   return (
-    <div 
-      className="flex flex-col justify-center items-start w-full text-white"
-      data-testid="topic-select"
-    >
+    <div className="flex flex-col justify-center items-start w-full text-white" data-testid="topic-select">
       <label htmlFor={isMulti ? 'tag-select' : 'single-tag-select'} className="block text-sm mb-2 font-medium text-gray-400">
         {isMulti ? 'Select/Create Tags' : 'Select Topic'}
       </label>
-      {isMulti
-        ?
+      {isMulti ?
         <CreatableSelect
           id='tag-select'
           isMulti
           value={selectedTags}
           onChange={handleChange}
           className="w-full"
-          styles={SelectStyles}      
-        />     
+          styles={SelectStyles}
+        />
         :
         <Select
           id='single-tag-select'
           value={selectedTags}
           onChange={handleChange}
-          options={tags}
+          options={topic_options}
           className="w-full"
-          styles={SelectStyles}      
-        />  
-    }  
+          styles={SelectStyles}
+        />
+      }
     </div>
   );
 }

--- a/codewit/client/src/components/form/VideoSelect.tsx
+++ b/codewit/client/src/components/form/VideoSelect.tsx
@@ -3,68 +3,104 @@ import { useState, useEffect } from 'react';
 import Select from 'react-select';
 import axios from 'axios';
 import { SelectStyles } from '../../utils/styles.js';
-import { YouTubeSearchResult } from '@codewit/interfaces'; 
+import { useQuery } from '@tanstack/react-query';
+import { Label } from 'flowbite-react';
 
 interface VideoSelectProps {
-  onSelectVideo: (videoId: string, videoThumbnail: string) => void;
-  selectedVideoId: string;
+  youtube_id: string,
+  required?: boolean,
+  onSelectVideo: (videoId: string, videoThumbnail: string) => void,
 }
 
-const VideoSelect = ({ onSelectVideo, selectedVideoId }: VideoSelectProps): JSX.Element => {
-  const [videos, setVideos] = useState<YouTubeSearchResult[]>([]);
-  const [selectedOption, setSelectedOption] = useState<any>(null);
-  const [error, setError] = useState<string | null>(null);
+interface VideoOption {
+  value: string,
+  label: string,
+  thumbnail: string,
+}
 
-  const fetchVideos = async () => {
-    const apiKey = import.meta.env.VITE_KEY;
-    const channelId = import.meta.env.VITE_CHANNEL_ID;
-    const url = `https://www.googleapis.com/youtube/v3/search?key=${apiKey}&channelId=${channelId}&part=snippet,id&order=date&type=video&maxResults=50`;
+const VideoSelect = ({ youtube_id, required = false, onSelectVideo }: VideoSelectProps): JSX.Element => {
+  const [selected_option, set_selected_option] = useState<VideoOption | null>(null);
 
-    try {
-      const response = await axios.get(url);
-      if (response.data.error) throw new Error(response.data.error.message);
+  const {data: videos, isFetching, error} = useQuery({
+    queryKey: ["youtube_videos"],
+    queryFn: async (): Promise<VideoOption[]> => {
+      const apiKey = import.meta.env.VITE_KEY;
+      const channelId = import.meta.env.VITE_CHANNEL_ID;
 
-      setVideos(response.data.items.map((item: YouTubeSearchResult) => ({
-        value: item.id.videoId,
-        label: item.snippet.title,
-        thumbnail: item.snippet.thumbnails.high.url, 
-      })));
-      setError(null);
-    } catch (err) {
-      setError('Failed to fetch videos. Please try again later.');
-      console.error('Failed to fetch videos:', err);
-    }
-  };
+      let rtn = [];
+      let next_page_token: string | null = null;
+
+      while (true) {
+        // results are paginated so if we are to show all of the videos in the
+        // select then we will need to retrieve all of the videos.
+        let url = `https://www.googleapis.com/youtube/v3/search?key=${apiKey}&channelId=${channelId}&part=snippet,id&order=date&type=video&maxResults=50`;
+
+        if (next_page_token != null) {
+          url += `&pageToken=${next_page_token}`;
+        }
+
+        const response = await axios.get(url);
+
+        if (response.data.error) {
+          throw new Error(response.data.error.message);
+        }
+
+        for (let item of response.data.items) {
+          rtn.push({
+            value: item.id.videoId,
+            label: item.snippet.title,
+            thumbnail: item.snippet.thumbnails.high.url,
+          });
+        }
+
+        if (response.data.nextPageToken != null) {
+          next_page_token = response.data.nextPageToken;
+        } else {
+          break;
+        }
+      }
+
+      return rtn;
+    },
+    // reduce the amount of times we will make the requests by caching the
+    // results.
+    staleTime: 5* 60 * 1000, // 5 minutes
+    gcTime: 5 * 60 * 1000, // 5 minutes
+    retry: false,
+  });
 
   useEffect(() => {
-    fetchVideos();
-  }, []);
+    if (youtube_id && videos != null) {
+      const found = videos.find(video => {
+        return video.value === youtube_id
+      });
 
-  useEffect(() => {
-    if (selectedVideoId) {
-      const preselectedOption = videos.find(video => video.value === selectedVideoId);
-      setSelectedOption(preselectedOption || null);
+      set_selected_option(found || null);
     }
-  }, [selectedVideoId, videos]);  
-
-  const handleChange = (selectedOption: { value: string, label: string, thumbnail: string }) => {
-    setSelectedOption(selectedOption);
-    onSelectVideo(selectedOption.value, selectedOption.thumbnail);
-  };
+  }, [youtube_id, videos]);
 
   return (
-    <div className="mb-5">
-      <label htmlFor="youtube_id" className="block mb-2 text-sm font-medium text-gray-400">Select YouTube Video</label>
+    <div className="space-y-2">
+      <Label htmlFor="youtube_id">
+        YouTube Video {required ? <span className="text-red-500">*</span> : null}
+      </Label>
       {error ? (
-        <div className="text-red-500">{error}</div>
+        <div className="text-red-500">Failed to fetch videos. Please try again later.</div>
       ) : (
         <Select
           id="youtube_id"
-          value={selectedOption}
-          onChange={handleChange}
+          value={selected_option ?? undefined}
+          placeholder={isFetching ? "Loading..." : "Select YouTube Video."}
+          onChange={(selected) => {
+            if (selected != null) {
+              set_selected_option(selected);
+              onSelectVideo(selected.value, selected.thumbnail);
+            }
+          }}
           options={videos}
           className="text-sm bg-blue text-white border-none w-full rounded-lg"
           styles={SelectStyles}
+          isDisabled={isFetching}
           menuPortalTarget={document.body}
           menuPosition="fixed"
           menuPlacement="auto"

--- a/codewit/client/src/components/ui/modal.tsx
+++ b/codewit/client/src/components/ui/modal.tsx
@@ -1,0 +1,27 @@
+import { Modal as FlowbitModal, ModalBodyProps, ModalFooterProps, ModalHeaderProps, ModalProps } from "flowbite-react";
+import { cn } from "../../utils/styles";
+
+export function Modal({className, ...props}: ModalProps) {
+    return <FlowbitModal className={cn(className)} {...props} />;
+}
+
+export function ModalHeader({className, ...props}: ModalHeaderProps) {
+  return <FlowbitModal.Header
+    className={cn("bg-gray-700 text-white px-6 py-3", className)}
+    {...props}
+  />;
+}
+
+export function ModalBody({className, ...props}: ModalBodyProps) {
+  return <FlowbitModal.Body
+    className={cn("bg-gray-800 p-6 space-y-6 overflow-visible", className)}
+    {...props}
+  />
+}
+
+export function ModalFooter({className, ...props}: ModalFooterProps) {
+  return <FlowbitModal.Footer
+    className={cn("bg-gray-800 px-6 py-3 flex justify-end", className)}
+    {...props}
+  />
+}

--- a/codewit/client/src/pages/DemoForm.tsx
+++ b/codewit/client/src/pages/DemoForm.tsx
@@ -1,18 +1,40 @@
 // codewit/client/src/pages/DemoForm.tsx
-import React, { useState } from "react";
-import ReusableModal from "../components/form/ReusableModal";
+import { useEffect, useMemo, useState } from "react";
 import ReusableTable from "../components/form/ReusableTable";
 import { toast } from "react-toastify";
 import VideoSelect from "../components/form/VideoSelect";
-import ExerciseSelect from "../components/form/ExerciseSelect";
-import TagSelect from "../components/form/TagSelect";
-import LanguageSelect from "../components/form/LanguageSelect";
+import { topic_options } from "../components/form/TagSelect";
+import { language_options, get_language_option } from "../components/form/LanguageSelect";
 import CreateButton from "../components/form/CreateButton";
-import { Demo } from "@codewit/interfaces";
-import { useFetchDemos, usePostDemo, usePatchDemo, useDeleteDemo } from "../hooks/useDemo";
-import { DemoResponse } from "@codewit/interfaces";
+import { DemoResponse, ExerciseResponse } from "@codewit/interfaces";
 import { isFormValid } from "../utils/formValidationUtils";
 import LoadingPage from "../components/loading/LoadingPage";
+import { Modal, ModalBody, ModalFooter, ModalHeader } from "../components/ui/modal";
+import { useField, useForm } from "@tanstack/react-form";
+import { Button, Label, TextInput } from "flowbite-react";
+import CreatableSelect from "react-select/creatable";
+import { cn, SelectStyles } from "../utils/styles";
+import Select from "react-select";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { ErrorView } from "../components/error/Error";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { Bars3Icon, TrashIcon } from "@heroicons/react/24/solid";
 
 interface DemoForm {
   uid?: number,
@@ -22,20 +44,17 @@ interface DemoForm {
   language: string,
   youtube_id: string,
   youtube_thumbnail: string,
-  exercises: number[]
+  exercises: DemoExercise[]
 }
 
-const DemoForm = (): JSX.Element => {
+interface DemoExercise {
+  uid: number,
+  prompt: string,
+}
 
-  const { data: demos, setData: setDemos } = useFetchDemos();
-  const postDemo = usePostDemo();
-  const patchDemo = usePatchDemo();
-  const deleteDemo = useDeleteDemo();
-
-  const [modalOpen, setModalOpen] = useState(false);
-  const [isEditing, setIsEditing] = useState(false);
-  const [formData, setFormData] = useState<DemoForm>({
-    uid: undefined as number | undefined,
+function blank_form(): DemoForm {
+  return {
+    uid: undefined,
     title: "",
     youtube_id: "",
     youtube_thumbnail: "",
@@ -43,67 +62,55 @@ const DemoForm = (): JSX.Element => {
     language: "cpp",
     tags: [],
     exercises: [],
+  };
+}
+
+function demo_form(given: DemoResponse): DemoForm {
+  return {
+    uid: given.uid,
+    title: given.title,
+    youtube_id: given.youtube_id,
+    youtube_thumbnail: given.youtube_thumbnail,
+    topic: given.topic,
+    language: given.language,
+    tags: given.tags,
+    exercises: given.exercises.map(({uid, prompt}) => ({uid, prompt})),
+  };
+}
+
+export default function DemoTable() {
+  const [edit_demo, set_edit_demo] = useState(blank_form());
+  const [view_edit, set_view_edit] = useState(false);
+
+  const client = useQueryClient();
+  const {data: demos, isFetching, error, refetch} = useQuery({
+    queryKey: ["search_demos"],
+    queryFn: async () => {
+      let result = await axios.get<DemoResponse[]>("/api/demos");
+
+      return result.data;
+    }
   });
 
-  const handleModalClose = () => {
-    setModalOpen(false);
-    setFormData({
-      uid: undefined,
-      title: "",
-      youtube_id: "",
-      youtube_thumbnail: "",
-      topic: "",
-      language: "cpp",
-      tags: [],
-      exercises: [],
-    });
-    setIsEditing(false);
-  };
+  const delete_demo = useMutation({
+    mutationFn: async (uid: number) => {
+      await axios.delete(`/api/demos/${uid}`);
+    },
+    onSuccess: (data, vars, ctx) => {
+      let current = client.getQueryData<DemoResponse[]>(["search_demos"]);
 
-  const handleInputChange = (name: string, value: any) => {
-    setFormData((prev) => ({ ...prev, [name]: value }));
-  };
+      if (current != null) {
+        let filtered = current.filter(demo => demo.uid !== vars);
 
-  const handleSubmit = async () => {
-    try {
-      if (isEditing) {
-        // @ts-ignore
-        const updatedDemo = await patchDemo(formData, formData.uid as unknown as number);
-        // @ts-ignore
-        setDemos((prev) => prev.map((demo) => (demo.uid === formData.uid ? updatedDemo : demo)));
-        toast.success("Demo successfully updated!");
-      } else {
-        // @ts-ignore
-        const newDemo = await postDemo(formData);
-        // @ts-ignore
-        setDemos((prev) => [...prev, newDemo]);
-        toast.success("Demo successfully created!");
+        client.setQueryData(["search_demos"], filtered);
       }
-      handleModalClose();
-    } catch {
-      toast.error("An error occurred. Please try again.");
-    }
-  };
 
- const handleEdit = (demo: DemoResponse) => {
-    setFormData(demo);
-    setIsEditing(true);
-    setModalOpen(true);
-  };
-
-  const handleDelete = async (demo: DemoResponse) => {
-    try {
-      await deleteDemo(demo.uid);
-      // @ts-ignore
-      setDemos((prev) => prev.filter((d) => d.uid !== demo.uid));
-      toast.success("Demo successfully deleted!");
-    } catch {
-      toast.error("An error occurred while deleting.");
-    }
-  };
-
-  const requiredFields = ["title", "youtube_id", "youtube_thumbnail", "topic"];
-  const isValid = isFormValid(formData, requiredFields);
+      toast.success("Demo deleted");
+    },
+    onError: (data, vars, ctx) => {
+      toast.error("Failed to delete demo. Please try again.");
+    },
+  });
 
   const columns = [
     { header: "Title", accessor: "title" },
@@ -111,80 +118,368 @@ const DemoForm = (): JSX.Element => {
     { header: "Language", accessor: "language" },
   ];
 
-  if (!demos) return <LoadingPage />;
+  if (demos == null && isFetching) {
+    return <LoadingPage />;
+  } else if (error != null) {
+    return <ErrorView title="Search Demos Error">
+      <p>There was an error when attempting to load demos</p>
+    </ErrorView>;
+  }
 
-  return (
+  return <>
     <div className="flex flex-col h-full bg-zinc-900 p-6">
-      <CreateButton onClick={() => setModalOpen(true)} title="Create Demo" />
-      <ReusableTable columns={columns} data={demos} onEdit={handleEdit} onDelete={handleDelete} />
-      <ReusableModal
-        isOpen={modalOpen}
-        onClose={handleModalClose}
-        title={isEditing ? "Edit Demo" : "Create Demo"}
-        footerActions={
-          <>
-            <button
-              onClick={handleSubmit}
-              data-testid="submit-button"
-              disabled={!isValid}
-              className={`px-4 py-2 rounded-md ${
-                isValid ? "bg-blue-500 text-white" : "bg-gray-500 text-gray-300 cursor-not-allowed"
-              }`}
-            >
-              {isEditing ? "Update" : "Create"}
-            </button>
-            <button onClick={handleModalClose} className="bg-gray-500 text-white px-4 py-2 rounded-md">
-              Cancel
-            </button>
-          </>
-        }
-      >
-        <div>
-          <label className="block mb-2 text-sm font-medium text-gray-400">Title</label>
-          <input
-            name='title'
-            data-testid='title'
-            value={formData.title}
-            onChange={(e) => handleInputChange("title", e.target.value)}
-            className="block w-full p-2 rounded-md bg-gray-700 text-white"
-            placeholder="Enter demo title"
-          />
+      <CreateButton title="Create Demo" onClick={() => {
+        set_view_edit(true);
+        set_edit_demo(blank_form());
+      }}/>
+      <ReusableTable
+        columns={columns}
+        data={demos ?? []}
+        onEdit={demo => {
+          set_view_edit(true);
+          set_edit_demo(demo_form(demo));
+        }}
+        onDelete={demo => {
+          delete_demo.mutate(demo.uid);
+        }}
+      />
+    </div>
+    <DemoForm
+      view={view_edit}
+      demo={edit_demo}
+      on_cancel={() => {
+        set_view_edit(false);
+      }}
+      on_created={demo => {
+        refetch();
+        set_view_edit(false);
+      }}
+      on_updated={demo => {
+        refetch();
+        set_view_edit(false);
+      }}
+    />
+  </>;
+}
+
+interface DemoFormProps {
+  view: boolean,
+  demo: DemoForm,
+  on_cancel: () => void,
+  on_created: (demo: DemoResponse) => void,
+  on_updated: (demo: DemoResponse) => void,
+}
+
+function DemoForm({view, demo, on_cancel, on_created, on_updated}: DemoFormProps) {
+  const send_demo = useMutation({
+    mutationFn: async (data: DemoForm) => {
+      let body = {
+        uid: data.uid ?? 0,
+        title: data.title,
+        youtube_id: data.youtube_id,
+        youtube_thumbnail: data.youtube_thumbnail,
+        topic: data.topic,
+        tags: data.tags,
+        language: data.language,
+        exercises: data.exercises.map(({uid}) => uid),
+      };
+
+      if (data.uid != null) {
+        return await axios.patch<DemoResponse>(`/api/demos/${data.uid}`, body);
+      } else {
+        return await axios.post<DemoResponse>("/api/demos", body);
+      }
+    },
+    onSuccess: (res, vars, ctx) => {
+      if (vars.uid != null) {
+        toast.success("Demo updated");
+
+        on_updated(res.data);
+      } else {
+        toast.success("Demo created");
+
+        on_created(res.data);
+      }
+    },
+    onError: (err, vars, ctx) => {
+      if (vars.uid == null) {
+        toast.error("Failed to create new demo. Please try again.");
+      } else {
+        toast.error("Failed to update demo. Please try again.");
+      }
+    }
+  });
+
+  const form = useForm({
+    defaultValues: demo,
+    onSubmit: async ({value}) => {
+      let result = await send_demo.mutateAsync(value);
+
+      form.reset(demo_form(result.data));
+    }
+  });
+
+  useEffect(() => {
+    form.reset(demo);
+  }, [demo.uid]);
+
+  useEffect(() => {
+    form.reset();
+  }, [view]);
+
+  return <Modal show={view} position="center" size="2xl" onClose={() => {
+    on_cancel();
+  }}>
+    <ModalHeader>
+      <form.Subscribe
+        selector={state => ([state.values.uid])}
+        children={([uid]) => uid != null ? "Edit Demo" : "Create Demo"}
+      />
+    </ModalHeader>
+    <form onSubmit={ev => {
+      ev.preventDefault();
+      ev.stopPropagation();
+
+      form.handleSubmit();
+    }}>
+      <ModalBody>
+        <form.Field name="title" children={(field) => {
+          return <div className="space-y-2">
+            <Label htmlFor={field.name}>
+              Title <span className="text-red-500">*</span>
+            </Label>
+            <TextInput
+              id={field.name}
+              name={field.name}
+              value={field.state.value}
+              onBlur={field.handleBlur}
+              onChange={ev => field.handleChange(ev.target.value)}
+            />
+          </div>;
+        }}/>
+        <form.Field name="youtube_id" children={(field) => {
+          return <VideoSelect required youtube_id={field.state.value} onSelectVideo={(id, thumbnail) => {
+            field.handleChange(id);
+            // have to use this since the id and thunbnail are tied to the same input
+            form.setFieldValue("youtube_thumbnail", thumbnail);
+          }}/>
+        }}/>
+        <form.Field name="topic" children={field => {
+          return <div className="space-y-2">
+            <Label htmlFor={field.name}>
+              Topic <span className="text-red-500">*</span>
+            </Label>
+            <Select
+              id={field.name}
+              name={field.name}
+              options={topic_options}
+              value={{label: field.state.value, value: field.state.value}}
+              onChange={value => field.handleChange(value?.value ?? "")}
+              styles={SelectStyles}
+            />
+          </div>
+        }}/>
+        <div className="grid grid-cols-2 gap-4">
+          <form.Field name="tags" mode="array" children={(field) => {
+            return <div className="space-y-2">
+              <Label htmlFor={field.name}>Tags</Label>
+              <CreatableSelect
+                isMulti
+                id={field.name}
+                value={field.state.value.map(tag => ({label: tag, value: tag}))}
+                onChange={(value) => field.handleChange(value.map(({value}) => value))}
+                styles={SelectStyles}
+              />
+            </div>
+          }}/>
+          <form.Field name="language" children={field => {
+            return <div className="space-y-2" data-testid="language-select">
+              <Label htmlFor={field.name}>Language</Label>
+              <Select
+                id={field.name}
+                name={field.name}
+                options={language_options}
+                value={get_language_option(field.state.value)}
+                onChange={value => field.handleChange(value?.value ?? "")}
+                isSearchable={false}
+                styles={SelectStyles}
+              />
+            </div>;
+          }}/>
         </div>
-        <VideoSelect
-          selectedVideoId={formData.youtube_id}
-          onSelectVideo={(id, thumbnail) => {
-            handleInputChange("youtube_id", id);
-            handleInputChange("youtube_thumbnail", thumbnail);
+        <form.Field name="exercises" mode="array" children={field => {
+          return <div className="border-t pt-2 space-y-2">
+            <Label>Exercises</Label>
+            <ExerciseSearch values={field.state.value} on_add={add => field.pushValue(add)}/>
+            <SortableExercise
+              values={field.state.value}
+              on_swap={(a_index, b_index) => field.moveValue(a_index, b_index)}
+              on_remove={(index, uid) => field.removeValue(index)}
+            />
+          </div>
+        }}/>
+      </ModalBody>
+      <ModalFooter>
+        <form.Subscribe
+          selector={state => ([
+            state.canSubmit,
+            state.isSubmitting,
+            state.values.uid,
+            state.isDirty,
+          ])}
+          children={([can_submit, is_submitting, uid, is_dirty]) => {
+            return <Button type="submit" disabled={!can_submit || !is_dirty}>
+              {is_submitting ? "..." : (uid != null ? "Update" : "Create")}
+            </Button>
           }}
         />
-        <ExerciseSelect
-          initialExercises={formData.exercises}
-          onSelectExercises={(exercises) => handleInputChange("exercises", exercises)}
-        />
-        <div className="grid grid-cols-2 gap-4">
-          <TagSelect
-            selectedTags={formData.tags.map((tag) => ({ label: tag, value: tag }))}
-            setSelectedTags={(tags) =>
-              handleInputChange(
-                "tags",
-                tags.map((tag: { value: string; }) => tag.value)
-              )
-            }
-            isMulti
-          />
-          <LanguageSelect
-            initialLanguage={formData.language}
-            handleChange={(e) => handleInputChange("language", e.target.value)}
-          />
-        </div>
-        <TagSelect
-          selectedTags={[{ value: formData.topic, label: formData.topic }]}
-          setSelectedTags={(topic) => handleInputChange("topic", topic.value)}
-          isMulti={false}
-        />
-      </ReusableModal>
-    </div>
-  );
-};
+        <Button type="button" color="dark" onClick={() => on_cancel()}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </form>
+  </Modal>
+}
 
-export default DemoForm;
+interface ExerciseSearchProps {
+  values: DemoExercise[],
+  on_add: (value: DemoExercise) => void,
+}
+
+function ExerciseSearch({values, on_add}: ExerciseSearchProps) {
+  const {data, isFetching, error} = useQuery({
+    queryKey: ["search_exercises"],
+    queryFn: async () => {
+      let result = await axios.get<ExerciseResponse[]>("/api/exercises");
+
+      return result.data.map(exercise => ({
+        value: exercise.uid,
+        label: exercise.prompt,
+        language: exercise.language,
+      }));
+    }
+  });
+
+  const avail = useMemo(() => {
+    // this could be a problem if the list gets big enough
+    return (data ?? []).filter(v => !values.find(a => v.value === a.uid));
+  }, [data, values]);
+
+  let placeholder = "Search Exercises";
+
+  if (isFetching) {
+    placeholder = "Loading...";
+  }
+
+  // this is going to be a bit janky but it will work
+  return <Select
+    id="exercise-search"
+    placeholder={placeholder}
+    styles={SelectStyles}
+    options={avail}
+    value={null}
+    onChange={value => {
+      if (value != null) {
+        on_add({uid: value.value, prompt: value.label});
+      }
+    }}
+    isDisabled={error != null}
+  />;
+}
+
+interface SortableExerciseProps {
+  values: DemoExercise[],
+  on_swap: (a_index: number, b_index: number) => void,
+  on_remove: (index: number, uid: number) => void,
+}
+
+function SortableExercise({values, on_swap, on_remove}: SortableExerciseProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates
+    })
+  );
+
+  function on_drag_end({active, over}: DragEndEvent) {
+    if (active.id !== over?.id) {
+      let a_index = null;
+      let b_index = null;
+
+      for (let index = 0; index < values.length; index += 1) {
+        if (active.id === values[index].uid) {
+          a_index = index;
+        }
+
+        if (over?.id === values[index].uid) {
+          b_index = index;
+        }
+
+        if (a_index != null && b_index != null) {
+          break;
+        }
+      }
+
+      if (a_index == null || b_index == null) {
+        console.log("a_index or b_index is null");
+
+        return;
+      }
+
+      on_swap(a_index, b_index);
+    }
+  }
+
+  return <div className="overflow-auto space-y-2">
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={on_drag_end}>
+      <SortableContext items={values.map(({uid}) => uid)} strategy={verticalListSortingStrategy}>
+        {values.map((exercise, index) => {
+          return <SortableExerciseItem key={exercise.uid} on_remove={() => on_remove(index, exercise.uid)} {...exercise}/>;
+        })}
+      </SortableContext>
+    </DndContext>
+  </div>
+}
+
+interface SortableExerciseItemProps {
+  uid: number,
+  prompt: string,
+  on_remove: () => void,
+}
+
+function SortableExerciseItem({uid, prompt, on_remove}: SortableExerciseItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({id: uid});
+
+  const style = {
+    //transform: transform != null ? `translate3d(${Math.round(transform.x)}px, ${Math.round(transform.y)}px, 0) scaleX(${transform.scaleX}) scaleY(${transform.scaleY})` : "",
+    transform: transform != null ? `translate3d(${Math.round(0)}px, ${Math.round(transform.y)}px, 0) scaleX(${transform.scaleX}) scaleY(${transform.scaleY})` : "",
+    transition,
+  };
+
+  // the colors for the container are pulled from the input styles of
+  // flowbit-react. if there is a specific className that can be used
+  // then they can be replaced, otherwise manually specifying the
+  // colors.
+  return <div
+    ref={setNodeRef}
+    className="border rounded-lg p-2 gap-x-2 flex flex-row items-center bg-[rgb(55,65,81)] border-[rgb(75,85,99)]"
+    style={style}
+  >
+    <div className="p-2" {...attributes} {...listeners}>
+      <Bars3Icon className="h-5 w-5"/>
+    </div>
+    <div className="flex-1">
+      <p className="truncate dark:text-white bg-">{prompt}</p>
+      <span className="text-sm dark:text-white">uid: {uid}</span>
+    </div>
+    <Button type="button" color="red" onClick={() => on_remove()}>
+      <TrashIcon className="h-6 w-6"/>
+    </Button>
+  </div>
+}

--- a/codewit/lib/shared/interfaces/src/lib/interfaces.ts
+++ b/codewit/lib/shared/interfaces/src/lib/interfaces.ts
@@ -69,7 +69,12 @@ interface DemoResponse {
   language: string,
   youtube_id: string,
   youtube_thumbnail: string,
-  exercises: number[]
+  exercises: DemoExercise[]
+}
+
+interface DemoExercise {
+  uid: number,
+  prompt: string,
 }
 
 interface DemoFormData {

--- a/codewit/package-lock.json
+++ b/codewit/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@heroicons/react": "^2.1.1",
         "@monaco-editor/react": "^4.6.0",
         "@nrwl/node": "^18.0.1",
@@ -38,6 +40,7 @@
         "redis": "^4.7.0",
         "remark-gfm": "^4.0.0",
         "sequelize": "^6.36.0",
+        "sequelize-cli": "^6.6.1",
         "tailwind-merge": "^2.6.0",
         "tslib": "^2.3.0",
         "unique-names-generator": "^4.7.1",
@@ -2552,6 +2555,59 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
@@ -4738,6 +4794,12 @@
         "tslib": "^2.3.0",
         "yargs-parser": "21.1.1"
       }
+    },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "license": "MIT"
     },
     "node_modules/@phenomnomnominal/tsquery": {
       "version": "5.0.1",
@@ -7198,6 +7260,15 @@
       "deprecated": "Use your platform's native atob() and btoa() methods instead",
       "dev": true
     },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -7600,9 +7671,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -8091,10 +8159,7 @@
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/body-parser": {
       "version": "1.20.1",
@@ -8820,6 +8885,22 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/config-chain/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
     },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
@@ -9804,6 +9885,48 @@
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/editorconfig": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
+      "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/minimatch": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ee-first": {
@@ -13830,6 +13953,71 @@
       "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
       "dev": true
     },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-beautify/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-beautify/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -15487,6 +15675,21 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="
     },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -16757,6 +16960,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "license": "ISC"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -17893,6 +18102,81 @@
         "tedious": {
           "optional": true
         }
+      }
+    },
+    "node_modules/sequelize-cli": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/sequelize-cli/-/sequelize-cli-6.6.3.tgz",
+      "integrity": "sha512-1YYPrcSRt/bpMDDSKM5ubY1mnJ2TEwIaGZcqITw4hLtGtE64nIqaBnLtMvH8VKHg6FbWpXTiFNc2mS/BtQCXZw==",
+      "license": "MIT",
+      "dependencies": {
+        "fs-extra": "^9.1.0",
+        "js-beautify": "1.15.4",
+        "lodash": "^4.17.21",
+        "picocolors": "^1.1.1",
+        "resolve": "^1.22.1",
+        "umzug": "^2.3.0",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "sequelize": "lib/sequelize",
+        "sequelize-cli": "lib/sequelize"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/sequelize-cli/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/sequelize-cli/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sequelize-cli/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sequelize-cli/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/sequelize-pool": {
@@ -19267,6 +19551,18 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
       "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA=="
+    },
+    "node_modules/umzug": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/umzug/-/umzug-2.3.0.tgz",
+      "integrity": "sha512-Z274K+e8goZK8QJxmbRPhl89HPO1K+ORFtm6rySPhFKfKc5GHhqdzD0SGhSWHkzoXasqJuItdhorSvY7/Cgflw==",
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "^3.7.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",

--- a/codewit/package.json
+++ b/codewit/package.json
@@ -14,6 +14,8 @@
   },
   "private": true,
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@heroicons/react": "^2.1.1",
     "@monaco-editor/react": "^4.6.0",
     "@nrwl/node": "^18.0.1",


### PR DESCRIPTION
this adds in the ability to specify the order of exercises for a demo. previously there was no order to specify and most of the test demos only had 1 exercise attached so it was not a problem. if more than one exercise is specified then there was no specified order in which they would be presented. a new field has been added that will specify the desired order and the interface has been updated to easily allow adding / re-ordering / removing of exercises for a demo. this also includes updates to the interface to use various tanstack libraries that have been added to the project. other additions also include
 - updated the seed-db to use a transaction that will prevent partial data from being submitted to the database.
 - the youtube select was not properly retrieving all the videos to be shown. it will now retrieve the list of all videos for the channel.

   note: I did run across quota errors when testing it out which will result in an error being displayed vs showing any data. if that happens the field will not be displayed which will prevent the value from being updated. if this happens more often then we will need to look into storing the list of videos available to reduce api hits or find another solution.
 - the demo page will now sort the demos available by language and then title of the demo.

some of the styling for the form will be off as I was using changes that are not included in this PR but will be in a different one.

the attempt page will also throw errors in this change. another PR includes changes for that page that will be reviewed once this is out.

closes #105 