### PR TITLE
styling fixes

### DIFF
--- a/codewit/client/index.html
+++ b/codewit/client/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="utf-8" />
     <title>codewit.us</title>

--- a/codewit/client/src/app/app.tsx
+++ b/codewit/client/src/app/app.tsx
@@ -44,76 +44,77 @@ export function App() {
   }
 
   return (
-    <div className="w-full h-screen bg-background-500">
+    <div className="w-screen h-screen flex flex-col flex-nowrap bg-background-500">
       <NavBar
         name={user ? user.username : ''}
         admin={user ? user.isAdmin : false}
         handleLogout={handleLogout}
         courseTitle={isLandingPage ? '' : courseTitle}
-        courseId={courseId}
       />
-      <Routes>
-        <Route
-          path="/"
-          element={ <Home /> }
-        />
-        <Route
-          path="/:course_id"
-          element={<CourseView onCourseChange={setCourseTitle} />}
-        />
-        <Route path="/read/:uid" element={<Read />} />
-        <Route
-          path="/usermanagement"
-          element={
-            user && user.isAdmin ? (
-              <UserManagement />
-            ) : (
-              <Navigate
-                to="/error"
-                state={{
-                  message:
-                    'Oops! Page does not exist. We will return you to the main page.',
-                  statusCode: 401,
-                }}
-              />
-            )
-          }
-        />
-        <Route
-          path="/create"
-          element={
-            user && user.isAdmin ? (
-              <Create />
-            ) : (
-              <Navigate
-                to="/error"
-                state={{
-                  message:
-                    'Oops! Page does not exist. We will return you to the main page.',
-                  statusCode: 401,
-                }}
-              />
-            )
-          }
-        >
-          <Route index element={<DemoForms />} />
-          <Route path="demo" element={<DemoForms />} />
-          <Route path="exercise" element={<ExerciseForms />} />
-          <Route path="module" element={<ModuleForm />} />
-          <Route path="resource" element={<ResourceForm />} />
-          <Route path="course" element={<CourseForm />} />
-        </Route>
-        <Route
-          path="/:courseId/dashboard"
-          element={
-            <DashboardGate>
-              <TeacherView onCourseChange={setCourseTitle} />
-            </DashboardGate>
-          }
-        />
-        <Route path="/error" element={<Error />} />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
+      <div className="relative flex-1 overflow-auto">
+        <Routes>
+          <Route
+            path="/"
+            element={<Home />}
+          />
+          <Route
+            path="/:course_id"
+            element={<CourseView onCourseChange={setCourseTitle} />}
+          />
+          <Route path="/read/:uid" element={<Read />} />
+          <Route
+            path="/usermanagement"
+            element={
+              user && user.isAdmin ? (
+                <UserManagement />
+              ) : (
+                <Navigate
+                  to="/error"
+                  state={{
+                    message:
+                      'Oops! Page does not exist. We will return you to the main page.',
+                    statusCode: 401,
+                  }}
+                />
+              )
+            }
+          />
+          <Route
+            path="/create"
+            element={
+              user && user.isAdmin ? (
+                <Create />
+              ) : (
+                <Navigate
+                  to="/error"
+                  state={{
+                    message:
+                      'Oops! Page does not exist. We will return you to the main page.',
+                    statusCode: 401,
+                  }}
+                />
+              )
+            }
+          >
+            <Route index element={<DemoForms />} />
+            <Route path="demo" element={<DemoForms />} />
+            <Route path="exercise" element={<ExerciseForms />} />
+            <Route path="module" element={<ModuleForm />} />
+            <Route path="resource" element={<ResourceForm />} />
+            <Route path="course" element={<CourseForm />} />
+          </Route>
+          <Route
+            path="/:courseId/dashboard"
+            element={
+              <DashboardGate>
+                <TeacherView onCourseChange={setCourseTitle} />
+              </DashboardGate>
+            }
+          />
+          <Route path="/error" element={<Error />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </div>
     </div>
   );
 }

--- a/codewit/client/src/components/error/Error.tsx
+++ b/codewit/client/src/components/error/Error.tsx
@@ -23,7 +23,7 @@ const Error = ({ message = "Oops! Page does not exist. We will return you to the
   const displayStatusCode = stateStatusCode || statusCode;
 
   return (
-    <div className="flex flex-col justify-center items-center bg-zinc-900 w-full h-container-full px-4 text-center">
+    <div className="flex flex-col justify-center items-center bg-zinc-900 w-full h-full px-4 text-center">
       <div className=" text-white rounded-md shadow-lg w-full max-w-xl mx-auto">
         <h1 className="inline-flex mb-4 text-7xl font-extrabold tracking-tight text-red-600 ">
           {displayStatusCode} 
@@ -43,7 +43,7 @@ type ErrorViewProps = PropsWithChildren<{
 }>;
 
 export function ErrorView({title = "Error", children}: ErrorViewProps) {
-  return <div className="flex flex-col justify-center items-center bg-zinc-900 w-full h-container-full px-4 text-center">
+  return <div className="flex flex-col justify-center items-center bg-zinc-900 w-full h-full px-4 text-center">
     <div className=" text-white rounded-md shadow-lg w-full max-w-xl mx-auto">
       {typeof title === "string" ?
         <h1 className="inline-flex mb-4 text-7xl font-extrabold tracking-tight text-red-600 ">

--- a/codewit/client/src/components/form/CreateButton.tsx
+++ b/codewit/client/src/components/form/CreateButton.tsx
@@ -11,11 +11,9 @@ const CreateButton: React.FC<CreateButtonProps> = ({
   onClick,
 })=> {
   return (
-  <div className="flex justify-end mb-2">
+  <div className="flex justify-end">
     <button className="flex bg-accent-500 text-white px-4 py-1 rounded-md" onClick={onClick}>
-      <PlusIcon 
-        className="w-6 h-6 mr-2"
-      />
+      <PlusIcon className="w-6 h-6 mr-2"/>
       {title}
     </button>
   </div>

--- a/codewit/client/src/components/form/ReusableModal.tsx
+++ b/codewit/client/src/components/form/ReusableModal.tsx
@@ -10,36 +10,22 @@ interface ReusableModalProps {
   footerActions: React.ReactNode;
 }
 
-const ReusableModal: React.FC<ReusableModalProps> = ({
+export default function ReusableModal({
   isOpen,
   onClose,
   title,
   children,
   footerActions,
-}) => {
-  return (
-    <Modal
-      show={isOpen}
-      onClose={onClose}
-      className="flex items-center justify-center"
-    >
-      <div className="relative bg-gray-800 rounded-lg shadow-lg w-full max-w-2xl mx-auto">
-        <Modal.Header className="bg-gray-700 text-white px-6 py-3 rounded-t-lg">
-          {title}
-        </Modal.Header>
-
-        <Modal.Body
-          className="p-6 bg-gray-800 space-y-6 overflow-visible"
-        >
-          {children}
-        </Modal.Body>
-
-        <Modal.Footer className="bg-gray-800 px-6 py-3 flex justify-end rounded-b-lg">
-          {footerActions}
-        </Modal.Footer>
-      </div>
-    </Modal>
-  );
+}: ReusableModalProps) {
+  return <Modal position="center" show={isOpen} onClose={onClose} size="2xl">
+    <Modal.Header className="bg-gray-700 text-white px-6 py-3">
+      {title}
+    </Modal.Header>
+    <Modal.Body className="bg-gray-800 p-6 space-y-6 overflow-visible">
+      {children}
+    </Modal.Body>
+    <Modal.Footer className="bg-gray-800 px-6 py-3 flex justify-end rounded-b-lg">
+      {footerActions}
+    </Modal.Footer>
+  </Modal>;
 };
-
-export default ReusableModal;

--- a/codewit/client/src/components/form/ReusableTable.tsx
+++ b/codewit/client/src/components/form/ReusableTable.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { Table, Pagination } from "flowbite-react";
 import LoadingPage from "../loading/LoadingPage";
 import type { CustomFlowbiteTheme } from "flowbite-react";
+import { cn } from "../../utils/styles";
 
 interface Column {
   header: string;
@@ -9,11 +10,12 @@ interface Column {
 }
 
 interface ReusableTableProps<T> {
-  columns: Column[];
-  data: T[];
-  onEdit: (item: T) => void;
-  onDelete: (item: T) => void;
-  itemsPerPage?: number;
+  columns: Column[],
+  data: T[],
+  className?: string,
+  itemsPerPage?: number,
+  onEdit: (item: T) => void,
+  onDelete: (item: T) => void,
 }
 
 const getNestedValue = (obj: any, path: string): any => {
@@ -45,9 +47,10 @@ const paginationTheme: CustomFlowbiteTheme["pagination"] = {
 const ReusableTable = <T extends { id?: string | number; uid?: string | number }>({
   columns,
   data,
+  className,
+  itemsPerPage = 15,
   onEdit,
   onDelete,
-  itemsPerPage = 14,
 }: ReusableTableProps<T>) => {
 
   useEffect(() => {
@@ -70,74 +73,57 @@ const ReusableTable = <T extends { id?: string | number; uid?: string | number }
     return <LoadingPage />;
   }
 
-  return (
-    <div className="rounded-md border border-gray-700 bg-gray-900 text-gray-400 h-full">
-      <div className="overflow-y-auto h-[80vh] rounded-t-md">
-        <Table
-          hoverable
-          striped
-          className="border-gray-700 bg-gray-900 text-gray-400"
-        >
-          <Table.Head className="bg-gray-800 text-white sticky top-0 z-10">
-            {columns.map((col) => (
-              <Table.HeadCell
-                key={col.header}
-                className="text-gray-300 font-semibold"
-              >
-                {col.header}
-              </Table.HeadCell>
-            ))}
-            <Table.HeadCell
-              className="text-gray-300 font-semibold"
-            >
-                Actions
+  return <div className={cn("flex flex-col rounded-md border border-gray-700 bg-gray-900 text-gray-400 h-full", className)}>
+    <div className="flex-1 overflow-y-auto rounded-t-md">
+      <Table hoverable striped className="border-gray-700 bg-gray-900 text-gray-400">
+        <Table.Head className="bg-gray-800 text-white sticky top-0 z-10">
+          {columns.map((col) => (
+            <Table.HeadCell key={col.header} className="text-gray-300 font-semibold">
+              {col.header}
             </Table.HeadCell>
-          </Table.Head>
-          <Table.Body className="divide-y divide-gray-700">
-            {currentData.map((item, index) => (
-              <Table.Row
-                key={index}
-                className="hover:bg-gray-800 transition-colors duration-300"
-              >
-                {columns.map((col) => (
-                  <Table.Cell key={col.accessor} className="text-gray-400">
-                    {(() => {
-                      const value = getNestedValue(item, col.accessor);
-                      return value !== null && value !== undefined
-                        ? String(value)
-                        : "-";
-                    })()}
-                  </Table.Cell>
-                ))}
-                <Table.Cell className="text-right space-x-2">
-                  <button
-                    onClick={() => onEdit(item)}
-                    className="text-sm font-medium text-blue-500 hover:text-blue-400 hover:underline transition-all rounded-md"
-                  >
-                    Edit
-                  </button>
-                  <button
-                    onClick={() => onDelete(item)}
-                    className="text-sm font-medium text-red-500 hover:text-red-400 hover:underline transition-all rounded-md"
-                  >
-                    Delete
-                  </button>
-                </Table.Cell>
-              </Table.Row>
-            ))}
-          </Table.Body>
-        </Table>
-      </div>
-      <div className="flex justify-center items-center bg-gray-800 text-white py-2 rounded-b-md">
-        <Pagination
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onPageChange={(page) => setCurrentPage(page)}
-          theme={paginationTheme}
-        />
-      </div>
+          ))}
+          <Table.HeadCell className="text-gray-300 font-semibold">
+              Actions
+          </Table.HeadCell>
+        </Table.Head>
+        <Table.Body className="divide-y divide-gray-700">
+          {currentData.map((item, index) => {
+            return <Table.Row key={index} className="hover:bg-gray-800 transition-colors duration-300">
+              {columns.map((col) => {
+                const value = getNestedValue(item, col.accessor);
+
+                return <Table.Cell key={col.accessor} className="text-gray-400">
+                  {value !== null && value !== undefined ? String(value) : "-"}
+                </Table.Cell>;
+              })}
+              <Table.Cell className="text-right space-x-2">
+                <button
+                  onClick={() => onEdit(item)}
+                  className="text-sm font-medium text-blue-500 hover:text-blue-400 hover:underline transition-all rounded-md"
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={() => onDelete(item)}
+                  className="text-sm font-medium text-red-500 hover:text-red-400 hover:underline transition-all rounded-md"
+                >
+                  Delete
+                </button>
+              </Table.Cell>
+            </Table.Row>
+          })}
+        </Table.Body>
+      </Table>
     </div>
-  );
+    <div className="flex flex-none justify-center items-center bg-gray-800 text-white py-2 rounded-b-md">
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={(page) => setCurrentPage(page)}
+        theme={paginationTheme}
+      />
+    </div>
+  </div>;
 };
 
 export default ReusableTable;

--- a/codewit/client/src/components/nav/Nav.tsx
+++ b/codewit/client/src/components/nav/Nav.tsx
@@ -33,7 +33,7 @@ const NavBar = ({
   return (
     <Navbar
       fluid={true}
-      className="bg-foreground-600 p-1 border-b border-background-400"
+      className="border-b bg-foreground-600 border-background-400 dark:bg-foreground-600 dark:border-background-400"
     >
       <Link to="/" className="block min-w-[9.1rem]">
         <img
@@ -55,29 +55,18 @@ const NavBar = ({
         <div className="flex items-center gap-4">
           {name && (
             <div className="flex items-center gap-2 text-accent-500">
-            {
-              admin ? (
-                <AcademicCapIcon className="h-6 w-6" />
-              ) : (
-                <UserCircleIcon className="h-6 w-6" />
-              )
-            }
+              {admin ? <AcademicCapIcon className="h-6 w-6" /> : <UserCircleIcon className="h-6 w-6" />}
               <span className="text-[20px] font-medium">{name}</span>
             </div>
           )}
 
-          <Button
-            size="sm"
+          <button
             data-testid="navbar-toggle"
+            className="h-9 px-3 relative flex items-center justify-center text-sm text-accent-600 hover:text-accent-700 bg-transparent dark:bg-transparent rounded-lg text-center font-medium focus:outline-none focus:ring-4"
             onClick={toggleNavbar}
-            className="text-accent-600 hover:text-accent-700"
           >
-            {isOpen ? (
-              <XMarkIcon className="h-6 w-6" />
-            ) : (
-              <Bars3Icon className="h-6 w-6" />
-            )}
-          </Button>
+            {isOpen ? <XMarkIcon className="h-6 w-6" /> : <Bars3Icon className="h-6 w-6" />}
+          </button>
         </div>
       </div>
 
@@ -89,8 +78,9 @@ const NavBar = ({
         <div className="flex justify-end p-2">
           <Button
             size="sm"
+            className="text-accent-500 hover:text-accent-700 bg-transparent dark:bg-transparent"
+            color="dark"
             onClick={toggleNavbar}
-            className="p-2 text-accent-500 hover:text-accent-700"
           >
             <XMarkIcon className="h-6 w-6" />
           </Button>

--- a/codewit/client/src/components/notfound/NotFound.tsx
+++ b/codewit/client/src/components/notfound/NotFound.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 
 const NotFoundPage = (): JSX.Element => {
   return (
-    <div className = "flex justify-center items-center bg-zinc-900 flex-col w-full h-container-full">
+    <div className = "flex justify-center items-center bg-zinc-900 flex-col w-full h-full">
       <p className="text-lg font-bold text-pink-800">404 ERROR</p>
       <h1 className="mt-3 text-2xl font-semibold text-white md:text-3xl">Page not found</h1>
       <p className="mt-4 text-center text-gray-500 dark:text-gray-400">Sorry, the page you are looking for doesn't exist. Here are some helpful links:</p>

--- a/codewit/client/src/components/placeholders.tsx
+++ b/codewit/client/src/components/placeholders.tsx
@@ -10,7 +10,7 @@ export function CenterPrompt({header, children}: CenterPrompt) {
       <h2 className="text-2xl text-white">{header}</h2> :
       header;
 
-  return <div className="h-container-full max-w-full flex items-center justify-center bg-zinc-900">
+  return <div className="h-full max-w-full flex items-center justify-center bg-zinc-900">
     <div className="w-1/2 flex flex-col flex-nowrap items-center bg-foreground-500 rounded-2xl p-4">
       {header_node}
       {children}

--- a/codewit/client/src/pages/Create.tsx
+++ b/codewit/client/src/pages/Create.tsx
@@ -12,7 +12,7 @@ const Create = (): JSX.Element => {
   );
 
   return (
-    <div className="md:flex w-full h-container-full">
+    <div className="md:flex w-full h-full">
       <div className="w-full md:w-52 bg-foreground-800 border-r border-gray-700">
         <div className="flex flex-col p-4 space-y-1">
           <Link to="/create/module" className={linkClass('/create/module')}>

--- a/codewit/client/src/pages/Home.tsx
+++ b/codewit/client/src/pages/Home.tsx
@@ -103,7 +103,7 @@ export default function Home() {
     student_list = <StudentCourseList courses={data.student}/>;
   }
 
-  return <div className="h-container-full max-w-full overflow-auto bg-zinc-900">
+  return <div className="h-full max-w-full bg-zinc-900">
     <div className="max-w-7xl mx-auto px-10 py-4 space-y-2">
       {instructor_list}
       {student_list}

--- a/codewit/client/src/pages/Read.tsx
+++ b/codewit/client/src/pages/Read.tsx
@@ -96,7 +96,7 @@ export default function Read() {
   }
 
   return (
-    <div className="h-container-full w-full overflow-auto flex flex-col md:flex-row bg-black">
+    <div className="h-full w-full overflow-auto flex flex-col md:flex-row bg-black">
       <LeftPanel info={data} module_id={module_id} course_id={course_id}/>
       {data.demo.exercises.length === 0 ?
         <div className="flex flex-col items-center justify-center w-full">
@@ -172,47 +172,45 @@ function LeftPanel({info, module_id, course_id}: LeftPanelProps) {
       </div>,
     }}
   >
-    <div className="w-full h-full">
+    <div className="w-full h-full flex flex-col">
       <VideoPlayer youtube_id={info.demo.youtube_id} title={info.demo.title} />
-      <div className="ml-2">
-        <div className="flex justify-between items-center mt-4">
-          <h2 data-testid="demo-title" className="text-3xl font-bold text-white">{info.demo.title}</h2>
-          <button
-            onClick={() => mutate({uid: info.demo.uid, like_demo: !is_liked})}
-            type="button"
-            data-testid="like-button"
-            className={cn(
-              "group px-2 py-1 text-md font-medium text-center flex items-center rounded-lg border-2 hover:bg-accent-400 focus:outline-none",
-              {"text-green-500 border-green-500": is_liked},
-              {"text-accent-400 border-accent-400": !is_liked}
-            )}
-          >
-            {is_liked ?
-              <HandThumbUpIcon className="w-6 h-6 mr-2 group-hover:text-white" />
-              :
-              <HandThumbUpIcon className="w-6 h-6 mr-2 group-hover:text-white" />
-            }
-            <span  className="group-hover:text-white">Like</span>
-          </button>
-        </div>
-        <div className="mt-2 flex items-center space-x-2 text-white">
-          {/*
-          // we have a way of specifying who the presenter is for the video
-          // then this can be used
-          <span className = "inline-flex justify-center items-center gap-1 text-lg font-medium"> 
-            by 
-            <UserCircleIcon className="w-7 h-7" />
-            Jessica
-          </span>
-          */}
-          {info.demo.tags.map(tag => (
-            <span key={tag} data-testid="author-tags" className="bg-blue-100 text-blue-800 text-xs font-medium me-2 px-2.5 py-0.5 rounded">{tag}</span>
-          ))}
-        </div>
-        <div className="mt-4 h-[26vh] overflow-y-auto">
-          <RelatedDemos demos={info.related_demos} module_id={module_id} course_id={course_id}/>
-          <HelpfulLinks links={info.resources}/>
-        </div>
+      <div className="flex justify-between items-center pl-2 mt-4">
+        <h2 data-testid="demo-title" className="text-3xl font-bold text-white">{info.demo.title}</h2>
+        <button
+          onClick={() => mutate({uid: info.demo.uid, like_demo: !is_liked})}
+          type="button"
+          data-testid="like-button"
+          className={cn(
+            "group px-2 py-1 text-md font-medium text-center flex items-center rounded-lg border-2 hover:bg-accent-400 focus:outline-none",
+            {"text-green-500 border-green-500": is_liked},
+            {"text-accent-400 border-accent-400": !is_liked}
+          )}
+        >
+          {is_liked ?
+            <HandThumbUpIcon className="w-6 h-6 mr-2 group-hover:text-white" />
+            :
+            <HandThumbUpIcon className="w-6 h-6 mr-2 group-hover:text-white" />
+          }
+          <span  className="group-hover:text-white">Like</span>
+        </button>
+      </div>
+      <div className="pl-2 mt-2 flex items-center space-x-2 text-white">
+        {/*
+        // we have a way of specifying who the presenter is for the video
+        // then this can be used
+        <span className = "inline-flex justify-center items-center gap-1 text-lg font-medium"> 
+          by 
+          <UserCircleIcon className="w-7 h-7" />
+          Jessica
+        </span>
+        */}
+        {info.demo.tags.map(tag => (
+          <span key={tag} data-testid="author-tags" className="bg-blue-100 text-blue-800 text-xs font-medium me-2 px-2.5 py-0.5 rounded">{tag}</span>
+        ))}
+      </div>
+      <div className="pl-2 flex-1 mt-4 overflow-y-auto">
+        <RelatedDemos demos={info.related_demos} module_id={module_id} course_id={course_id}/>
+        <HelpfulLinks links={info.resources}/>
       </div>
     </div>
   </Resizable>;

--- a/codewit/client/src/pages/UserManagement.tsx
+++ b/codewit/client/src/pages/UserManagement.tsx
@@ -94,7 +94,7 @@ const UserManagement: React.FC = () => {
 
   return (
     <div 
-      className="flex flex-col items-center w-full h-container-full bg-zinc-900 p-6 overflow-y-auto"
+      className="flex flex-col items-center w-full h-full bg-zinc-900 p-6 overflow-y-auto"
     >
       <div className="mb-6 w-full max-w-7xl">
         <div className="flex">

--- a/codewit/client/src/pages/course/StudentView.tsx
+++ b/codewit/client/src/pages/course/StudentView.tsx
@@ -28,7 +28,7 @@ export default function StudentView({course}: StudentViewProps) {
   });
 
   if (course.modules.length === 0) {
-    return <div className="h-container-full max-w-full flex items-center justify-center bg-zinc-900">
+    return <div className="h-full max-w-full flex items-center justify-center bg-zinc-900">
       <div className="w-1/2 flex flex-col flex-nowrap items-center bg-foreground-500 rounded-2xl p-4">
         <h2 className="text-2xl text-white">No Modules for Course</h2>
         <p className="text-center text-white">
@@ -83,7 +83,7 @@ export default function StudentView({course}: StudentViewProps) {
     </div>);
   }
 
-  return <div className="h-container-full max-w-full overflow-auto bg-zinc-900">
+  return <div className="h-full max-w-full overflow-auto bg-zinc-900">
     <div className="max-w-7xl mx-auto px-10 py-4 space-y-2">
       {modules}
     </div>

--- a/codewit/client/src/pages/course/TeacherView.tsx
+++ b/codewit/client/src/pages/course/TeacherView.tsx
@@ -44,7 +44,7 @@ export default function TeacherView({ onCourseChange }: TeacherViewProps) {
   const Topics = course.modules.map(m => m.topic);
 
   return (
-    <div className="h-container-full overflow-auto flex flex-col w-full bg-black items-center gap-2">
+    <div className="h-full overflow-auto flex flex-col w-full bg-black items-center gap-2">
 
       {/* ───────── header + invite link ───────── */}
       <div className="bg-foreground-600 w-3/4 mt-4 rounded-md p-4">

--- a/codewit/client/tailwind.config.js
+++ b/codewit/client/tailwind.config.js
@@ -1,10 +1,11 @@
 /* v8 ignore next 98 */
 const { createGlobPatternsForDependencies } = require('@nx/react/tailwind');
-const flowbite = require('flowbite-react/tailwind');
 const { join } = require('path');
+const flowbite = require("flowbite-react/tailwind");
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  base: "",
   content: [
     join(
       __dirname,
@@ -12,18 +13,9 @@ module.exports = {
     ),
     // Add shared library components to content
     join(__dirname, '../lib/shared/components/**/*.{ts,tsx}'),
-    // similar to below, the path that this outputs is expecting a directory
-    // structure that does not exist for this project. the path that
-    // `flowbite.content()` gives will not be found unless it is modified or
-    // the location of this file changes
-    //flowbite.content(),
     ...createGlobPatternsForDependencies(__dirname),
     './src/**/*.{js,jsx,ts,tsx}',
-    // the previous path did not properly include the tailwindcss from flowbite
-    // and because of that the proper styling was not included for the
-    // components. because of this if it is properly included parse of the site
-    // are no longer properly styled.
-    //"../node_modules/flowbite-react/dist/{esm,cjs}/**/*.{mjs,cjs}",
+    flowbite.content({base: "../"}),
   ],
   theme: {
     screens: {
@@ -116,7 +108,6 @@ module.exports = {
   },
   plugins: [
     require('@tailwindcss/typography'),
-    flowbite.plugin(),
     require('daisyui'),
   ],
 };


### PR DESCRIPTION
this includes various updates to the styling of the site to properly include the flowbite styles.
 - the site will is specified to always be in dark mode (you can specify a style to be dark mode only in the tailwind classes by having "dark:..." in front)
 - the top level app container will now be properly sized and provide overflow that will allow the nav bar to be visible all the time.
 - various elements have been updated to remove the "h-container-full" as it is no longer needed. if an element is placed directly inside of the app main body then you should only need to specify "h-full"
 - the "ReusableModal" has been updated to better use the flowbite styles and be properly positioned to the center of the screen.
 - the "ReusableTable" has been updated with better styling and fixed some styling issues.
   - the pagination buttons will now be properly positioned at the bottom of the table and not have spacing beneath it.
   - cleaned up some of the logic around row mapping to make it easier to read.
   - changed the default "itemsPerPage" to be 15
   - added in a "className" prop for the top level div
 - fixed some styling issues around for the lower section of the demo beneath the video.

Note: there are still some styling issues in the create pages that I have not pinned down so it is possible to get the scroll bar for  the table and the main app body.