### PR TITLE
Navbar Course Title Link

### DIFF
--- a/codewit/api/src/routes/course.ts
+++ b/codewit/api/src/routes/course.ts
@@ -305,16 +305,6 @@ courseRouter.get('/:uid', asyncHandle(async (req, res) => {
   }
 }));
 
-courseRouter.get('/teacher/:id', async (req, res) => {
-  try {
-    const courses = await getTeacherCourses(req.params.id);
-    res.json(courses);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ message: 'Server error' });
-  }
-});
-
 courseRouter.post('/', checkAdmin, async (req, res) => {
   try {
     const validatedBody = createCourseSchema.safeParse(req.body);

--- a/codewit/client/src/app/app.tsx
+++ b/codewit/client/src/app/app.tsx
@@ -17,11 +17,17 @@ import Error from '../components/error/Error';
 import LoadingPage from '../components/loading/LoadingPage';
 import TeacherView from '../pages/course/TeacherView';
 import DashboardGate from '../components/guards/DashboardGate';
+import axios from 'axios';
+
+const TOP_LEVEL = new Set(['', 'create', 'usermanagement', 'read', 'settings', 'login', 'error']);
 
 export function App() {
   const { user, loading, handleLogout } = useAuth();
   const location = useLocation();
+  
   const isLandingPage = location.pathname === '/';
+  const isUserManagement = location.pathname.startsWith('/usermanagement');
+  
   const [courseTitle, setCourseTitle] = useState<string>(() =>
      localStorage.getItem('courseTitle') || '',
    );
@@ -36,8 +42,42 @@ export function App() {
     }
     if (courseId) { 
       localStorage.setItem('courseId', courseId);
-  }
+    }
   }, [courseTitle, courseId]);
+
+   // Get course from /api/courses/landing
+  useEffect(() => {
+    if (user?.isAdmin && !courseId) {
+      axios.get('/api/courses/landing')
+        .then(({ data }) => {
+          const first = data?.instructor?.[0];
+          if (first?.id && first?.title) {
+            setCourseId(first.id);
+            setCourseTitle(first.title);
+          }
+        })
+        .catch(() => {});
+    }
+  }, [user?.isAdmin, courseId]);
+  
+  // Derive courseId from the current URL for students (and /read)
+  useEffect(() => {
+    const segs = location.pathname.split('/').filter(Boolean);
+
+    // "/:courseId"
+    if (segs.length === 1 && !TOP_LEVEL.has(segs[0])) {
+      if (segs[0] !== courseId) setCourseId(segs[0]);
+      return;
+    }
+    // "/:courseId/dashboard"
+    if (segs.length === 2 && segs[1] === 'dashboard' && !TOP_LEVEL.has(segs[0])) {
+      if (segs[0] !== courseId) setCourseId(segs[0]);
+      return;
+    }
+    // read page: ?course_id=...
+    const qp = new URLSearchParams(location.search).get('course_id');
+    if (qp && qp !== courseId) setCourseId(qp);
+  }, [location.pathname, location.search, courseId]);
 
   if (loading) {
     return <LoadingPage />;
@@ -49,7 +89,7 @@ export function App() {
         name={user ? user.username : ''}
         admin={user ? user.isAdmin : false}
         handleLogout={handleLogout}
-        courseTitle={isLandingPage ? '' : courseTitle}
+        courseTitle={(isLandingPage || isUserManagement) ? '' : (courseTitle || '')}
         courseId={courseId}
       />
       <Routes>
@@ -66,7 +106,7 @@ export function App() {
           path="/usermanagement"
           element={
             user && user.isAdmin ? (
-              <UserManagement />
+              <UserManagement  />
             ) : (
               <Navigate
                 to="/error"

--- a/codewit/client/src/components/nav/Nav.tsx
+++ b/codewit/client/src/components/nav/Nav.tsx
@@ -2,15 +2,8 @@
 import { useState } from 'react';
 import { Navbar, Button } from 'flowbite-react';
 import { Link, useLocation } from 'react-router-dom';
-import {
-  ArrowLeftStartOnRectangleIcon,
-  Bars3Icon,
-  XMarkIcon,
-} from '@heroicons/react/24/solid';
-import {
-  UserCircleIcon
-} from '@heroicons/react/24/outline';
-import { AcademicCapIcon } from '@heroicons/react/24/outline';
+import { ArrowLeftStartOnRectangleIcon, Bars3Icon, XMarkIcon } from '@heroicons/react/24/solid';
+import { UserCircleIcon, AcademicCapIcon } from '@heroicons/react/24/outline';
 import GoogleLogo from '../logo/GoogleLogo';
 
 const NavBar = ({
@@ -18,102 +11,78 @@ const NavBar = ({
   admin,
   handleLogout,
   courseTitle,
+  courseId,
 }: {
   name: string;
   admin: boolean;
   handleLogout: () => void;
   courseTitle?: string;
+  courseId?: string;
 }): JSX.Element => {
   const [isOpen, setIsOpen] = useState(false);
+  const toggleNavbar = () => setIsOpen(!isOpen);
 
-  const toggleNavbar = () => {
-    setIsOpen(!isOpen);
-  };
+  const { search } = useLocation();
+
+  const params = new URLSearchParams(search);
+  const slugFromQuery = params.get('course_id');
+
+  const courseSlug = slugFromQuery || courseId || null;
+
+  const courseHref = courseSlug
+    ? (admin ? `/${courseSlug}/dashboard` : `/${courseSlug}`)
+    : null;
 
   return (
-    <Navbar
-      fluid={true}
-      className="bg-foreground-600 p-1 border-b border-background-400"
-    >
+    <Navbar fluid className="bg-foreground-600 p-1 border-b border-background-400">
+      {/* Logo → Landing */}
       <Link to="/" className="block min-w-[9.1rem]">
-        <img
-          src="/logo-dark.png"
-          className="w-[9.1rem] h-[2.5rem]"
-          alt="CodeWitUs Logo"
-        />
+        <img src="/logo-dark.png" className="w-[9.1rem] h-[2.5rem]" alt="CodeWitUs Logo" />
       </Link>
 
       <div className="flex items-center justify-between flex-grow">
         <div className="flex items-center">
-          {courseTitle && (
-            <span className="ml-10 text-[16px] font-bold text-foreground-200">
+          {courseTitle && courseHref && (
+            <Link
+              to={courseHref}
+              className="ml-10 text-[16px] font-bold text-foreground-200 hover:underline underline-offset-4"
+              aria-label={admin ? 'Go to Teacher Dashboard' : 'Go to Course'}
+            >
               {courseTitle}
-            </span>
+            </Link>
           )}
         </div>
 
         <div className="flex items-center gap-4">
           {name && (
             <div className="flex items-center gap-2 text-accent-500">
-            {
-              admin ? (
-                <AcademicCapIcon className="h-6 w-6" />
-              ) : (
-                <UserCircleIcon className="h-6 w-6" />
-              )
-            }
+              {admin ? <AcademicCapIcon className="h-6 w-6" /> : <UserCircleIcon className="h-6 w-6" />}
               <span className="text-[20px] font-medium">{name}</span>
             </div>
           )}
-
-          <Button
-            size="sm"
-            data-testid="navbar-toggle"
-            onClick={toggleNavbar}
-            className="text-accent-600 hover:text-accent-700"
-          >
-            {isOpen ? (
-              <XMarkIcon className="h-6 w-6" />
-            ) : (
-              <Bars3Icon className="h-6 w-6" />
-            )}
+          <Button size="sm" data-testid="navbar-toggle" onClick={toggleNavbar} className="text-accent-600 hover:text-accent-700">
+            {isOpen ? <XMarkIcon className="h-6 w-6" /> : <Bars3Icon className="h-6 w-6" />}
           </Button>
         </div>
       </div>
 
-      <div
-        className={`fixed top-0 right-0 w-64 h-screen bg-foreground-700 shadow-lg z-50 flex flex-col transform transition-transform duration-300 ease-in-out ${
-          isOpen ? 'translate-x-0' : 'translate-x-full'
-        }`}
-      >
+      {/* drawer … unchanged */}
+      <div className={`fixed top-0 right-0 w-64 h-screen bg-foreground-700 shadow-lg z-50 flex flex-col transform transition-transform duration-300 ease-in-out ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}>
         <div className="flex justify-end p-2">
-          <Button
-            size="sm"
-            onClick={toggleNavbar}
-            className="p-2 text-accent-500 hover:text-accent-700"
-          >
+          <Button size="sm" onClick={toggleNavbar} className="p-2 text-accent-500 hover:text-accent-700">
             <XMarkIcon className="h-6 w-6" />
           </Button>
         </div>
         <div className="flex flex-col px-4 space-y-4">
-          <Link
-            to="/"
-            className="block px-3 p-1 rounded-md text-base font-medium text-accent-500 hover:text-white hover:bg-accent-600"
-          >
+          <Link to="/" className="block px-3 p-1 rounded-md text-base font-medium text-accent-500 hover:text-white hover:bg-accent-600">
             Home
           </Link>
           {admin && (
             <>
-              <Link
-                to="/create"
-                className="block px-3 p-1 rounded-md text-base font-medium text-accent-500 hover:text-white hover:bg-accent-600"
-              >
+              <Link to="/create" className="block px-3 p-1 rounded-md text-base font-medium text-accent-500 hover:text-white hover:bg-accent-600">
                 Create
               </Link>
-              <Link
-                to="/usermanagement"
-                className="block px-3 p-1 rounded-md text-base font-medium text-accent-500 hover:text-white hover:bg-accent-600"
-              >
+              <Link to="/usermanagement" className="block px-3 p-1 rounded-md text-base font-medium text-accent-500 hover:text-white hover:bg-accent-600">
                 Manage Users
               </Link>
             </>
@@ -131,11 +100,7 @@ const NavBar = ({
               </Button>
             </div>
           ) : (
-            <form
-              action="http://localhost:3001/oauth2/google"
-              method="get"
-              className="w-full"
-            >
+            <form action="http://localhost:3001/oauth2/google" method="get" className="w-full">
               <button
                 type="submit"
                 className="w-full bg-white text-gray-600 hover:bg-gray-100 border border-gray-300 rounded-lg py-2 px-4 flex items-center gap-3 shadow-md transition-all"

--- a/codewit/client/src/pages/CourseView.tsx
+++ b/codewit/client/src/pages/CourseView.tsx
@@ -68,14 +68,8 @@ export default function CourseView({onCourseChange}: CourseView) {
   const { data: course, loading, error, setData } = useAxiosFetch<GetCourse | null>(`/api/courses/${course_id}?student_view=1&r=${refresh}`, null);
 
   useEffect(() => {
-    if (course != null) {
-      if (course.type === "StudentView") {
-        onCourseChange(course.title);
-      } else {
-        onCourseChange("");
-      }
-    } else {
-      onCourseChange("");
+    if (course?.type === "StudentView") {
+      onCourseChange(course.title);
     }
   }, [course, onCourseChange]);
 

--- a/codewit/client/src/pages/UserManagement.tsx
+++ b/codewit/client/src/pages/UserManagement.tsx
@@ -29,7 +29,7 @@ const UserManagement: React.FC = () => {
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [showModal, setShowModal] = useState<boolean>(false);
   const [page, setPage] = useState(0);
-  
+
 
   const searchUser = useSearchUser();
   const setAdmin = useSetAdmin();
@@ -38,9 +38,10 @@ const UserManagement: React.FC = () => {
   const goToPage = (n: number) => {
     setPage(n);
   };
+  const totalPages = Math.max(1, Math.ceil((filteredUsers?.length ?? 0) / pageSize));
 
   useEffect(() => {
-    if (allUsers.length) {
+    if (Array.isArray(allUsers) && allUsers.length) {
       setFilteredUsers(allUsers); 
       setPage(0);
     }
@@ -49,7 +50,7 @@ const UserManagement: React.FC = () => {
   const handleSearch = async () => {
     if (!searchQuery.trim()) {
       // Empty search = reset to full list
-      setFilteredUsers(allUsers);
+      setFilteredUsers(allUsers ?? []);
       return; 
     }
 
@@ -179,7 +180,7 @@ const UserManagement: React.FC = () => {
       </div>
       <div className="w-full max-w-7xl flex justify-between items-center mt-4 px-2">
         <p className="text-sm text-gray-400">
-          Page {page + 1} of {Math.ceil(filteredUsers.length / pageSize)}
+          Page {Math.min(page + 1, totalPages)} of {totalPages}
         </p>
         <div className="flex gap-2">
           <button

--- a/codewit/client/src/pages/course/TeacherView.tsx
+++ b/codewit/client/src/pages/course/TeacherView.tsx
@@ -27,8 +27,6 @@ export default function TeacherView({ onCourseChange }: TeacherViewProps) {
   useEffect(() => {
     if (course != null) {
       onCourseChange(course.title);
-    } else {
-      onCourseChange("");
     }
   }, [course, onCourseChange]);
 


### PR DESCRIPTION
## Navbar course title → role-aware link

### **Before:** Course title in the Navbar was hardcoded text (not clickable).
### **After:** Title is a role-aware link:

- **Teacher** → `/:courseId/dashboard`, 
- **Student** → `/:courseId` — works from `/create`, `/:courseId`, and `/read/:uid?course_id=…`. 
- The title is hidden on `/` and `/usermanagement`.

### Changes
- Make **App** the single source of truth for `courseId` / `courseTitle`.
- Bootstrap teacher course on cold start via **`GET /api/courses/landing`**.
- Derive `courseId` from path (`/:courseId`, `/:courseId/dashboard`) or `?course_id` (on `/read`).
- Simplify **Nav** to a presentational component: builds href from props.
- Set the course title only when data is known in **TeacherView** / **CourseView**.

### Verification
- `/create` (teacher): title shows → links to `/:courseId/dashboard`.
- `/:courseId` (student): title shows → links to `/:courseId`.
- `/read/:uid?course_id=…`: link targets that course immediately.
- `/` and `/usermanagement`: title is hidden.
