### PR TITLE
feat(teacher-dashboard): export student progress to CSV from Student Progress card

### DIFF
--- a/codewit/api/src/routes/course.ts
+++ b/codewit/api/src/routes/course.ts
@@ -33,7 +33,6 @@ import {
 import { asyncHandle } from "../middleware/catch";
 import {  } from "../models";
 import { formatCourseResponse } from '../utils/responseFormatter';
-import { Op } from 'sequelize';
 
 interface UserStatus {
   is_instructor: boolean,

--- a/codewit/client/src/pages/course/TeacherView.tsx
+++ b/codewit/client/src/pages/course/TeacherView.tsx
@@ -8,7 +8,7 @@ import { default as ErrorEle } from '../../components/error/Error';
 import { useAxiosFetch } from "../../hooks/fetching";
 import { useEffect, useState } from "react";
 import PendingRequestsCard from './components/PendingRequestsCard';
-import type { Course } from '@codewit/interfaces';
+import type { Course, StudentProgress } from '@codewit/interfaces';
 import { useQuery } from "@tanstack/react-query";
 import axios from 'axios';
 import { toast } from 'react-toastify';
@@ -119,10 +119,15 @@ export default function TeacherView({ onCourseChange }: TeacherViewProps) {
         return;
       }
 
+      if (!course) {
+        toast.error('Course not loaded.');
+        return;
+      }
+
       // Roster lookup for email
-      const rosterArr = (course as any)?.roster ?? [];
-      const rosterByUid = new Map<number, any>(
-        Array.isArray(rosterArr) ? rosterArr.map((u: any) => [u.uid, u]) : []
+      const rosterArr = course.roster ?? [];
+      const rosterByUid = new Map<number, Course['roster'][number]>(
+        rosterArr.map((u) => [u.uid, u])
       );
 
       const header = [
@@ -135,11 +140,11 @@ export default function TeacherView({ onCourseChange }: TeacherViewProps) {
 
       const lines: string[] = [header];
 
-      const sorted = [...students].sort((a, b) =>
+      const sorted: StudentProgress[] = [...students].sort((a, b) =>
         (a.studentName || '').localeCompare(b.studentName || '', undefined, { sensitivity: 'base' })
       );
 
-      for (const s of (sorted as any[])) {
+      for (const s of sorted) {
         const email = (rosterByUid.get(s.studentUid)?.email ?? '').trim();
 
         lines.push([

--- a/codewit/lib/shared/interfaces/src/lib/interfaces.ts
+++ b/codewit/lib/shared/interfaces/src/lib/interfaces.ts
@@ -171,6 +171,8 @@ export interface StudentProgress {
   studentUid: number;
   studentName: string;
   completion: number;
+  modulesCompleted: number;
+  modulesTotal: number;
 }
 
 export interface TeacherCourse{


### PR DESCRIPTION
## Summary:

Adds an Export CSV button to the Student Progress card on the Teacher Dashboard. The CSV is built client-side from the data already displayed on the page and downloads immediately.

### CSV columns (in order):

- 	Name (studentName)
- 	Email (from course.roster)
- 	Modules Completed
- 	Modules Total
- 	Completion % (two decimals; no “%”)

**File Saved As:** Filename: course-<courseId>-students-summary-YYYYMMDD.csv

Fixes #98