### PR TITLE
Add data analysis options to topics tree for pandas videos

### DIFF
--- a/codewit/lib/shared/topics/src/lib/topicstree.ts
+++ b/codewit/lib/shared/topics/src/lib/topicstree.ts
@@ -84,6 +84,13 @@ const topicTree = {
   "testing": {
     "assert": {},
     "unit test": {}
+  },
+  "data analysis": {
+    "load dataframe": {},
+    "describe dataframe": {},
+    "melt dataframe": {},
+    "pivot dataframe": {},
+    "query dataframe": {}
   }
 }
 


### PR DESCRIPTION
We have python videos that demonstrate some basic data science fundamentals. This adds `data analysis` as a parent-level category of topics and several dataframe manipulation topics as children.