### PR TITLE
Fix ReusableTable types for Course/Demo/Module/Resource pages

### DIFF
--- a/codewit/client/src/pages/CourseForm.tsx
+++ b/codewit/client/src/pages/CourseForm.tsx
@@ -1,6 +1,6 @@
 // codewit/client/src/pages/CourseForm.tsx
 import React, { useState, useEffect } from "react";
-import ReusableTable from "../components/form/ReusableTable";
+import ReusableTable, { Column } from "../components/form/ReusableTable";
 import ReusableModal from "../components/form/ReusableModal";
 import Select, { MultiValue } from "react-select";
 import LanguageSelect from "../components/form/LanguageSelect";
@@ -136,11 +136,11 @@ export default function CourseForm() {
   const requiredFields = ["title"];
   const isValid = isFormValid(formData, requiredFields);
 
-  const columns = [
+  const columns: Column<Course>[] = [
     { header: "Title", accessor: "title" },
-    { header: "Modules", accessor: "modules.length" },
-    { header: "Instructors", accessor: "instructors.length" },
-    { header: "Roster", accessor: "roster.length" },
+    { header: "Modules", accessor: (c: Course) => c.modules.length },
+    { header: "Instructors", accessor: (c: Course) => c.instructors.length },
+    { header: "Roster", accessor: (c: Course) => c.roster.length },
   ];
 
   return (

--- a/codewit/client/src/pages/DemoForm.tsx
+++ b/codewit/client/src/pages/DemoForm.tsx
@@ -1,6 +1,6 @@
 // codewit/client/src/pages/DemoForm.tsx
 import { useEffect, useMemo, useState } from "react";
-import ReusableTable from "../components/form/ReusableTable";
+import ReusableTable, { Column } from "../components/form/ReusableTable";
 import { toast } from "react-toastify";
 import VideoSelect from "../components/form/VideoSelect";
 import { topic_options } from "../components/form/TagSelect";
@@ -112,7 +112,7 @@ export default function DemoTable() {
     },
   });
 
-  const columns = [
+  const columns: Column<DemoResponse>[] = [
     { header: "Title", accessor: "title" },
     { header: "Topic", accessor: "topic" },
     { header: "Language", accessor: "language" },

--- a/codewit/client/src/pages/ModuleForm.tsx
+++ b/codewit/client/src/pages/ModuleForm.tsx
@@ -5,7 +5,7 @@ import LanguageSelect from "../components/form/LanguageSelect";
 import TopicSelect from "../components/form/TagSelect";
 import ResourceSelect from "../components/form/ResourceSelect";
 import CreateButton from "../components/form/CreateButton";
-import ReusableTable from "../components/form/ReusableTable";
+import ReusableTable, { Column } from "../components/form/ReusableTable";
 import ReusableModal from "../components/form/ReusableModal";
 import { toast } from "react-toastify";
 import { SelectedTag, Module } from "@codewit/interfaces";
@@ -119,10 +119,10 @@ const ModuleForm = (): JSX.Element => {
   const requiredFields = ["topic", "language"];
   const isValid = isFormValid(formData, requiredFields);
 
-  const columns = [
+  const columns: Column<Module>[] = [
     { header: "Topic", accessor: "topic" },
     { header: "Language", accessor: "language" },
-    { header: "Resources", accessor: "resources.length" },
+    { header: "Resources", accessor: (m: Module) => m.resources.length },
   ];
 
   return (

--- a/codewit/client/src/pages/ResourceForm.tsx
+++ b/codewit/client/src/pages/ResourceForm.tsx
@@ -1,6 +1,6 @@
 // codewit/client/src/pages/ResourceForm.tsx
 import React, { useState, useEffect } from "react";
-import ReusableTable from "../components/form/ReusableTable";
+import ReusableTable, { Column } from "../components/form/ReusableTable";
 import ReusableModal from "../components/form/ReusableModal";
 import InputLabel from "../components/form/InputLabel";
 import TextInput from "../components/form/TextInput";
@@ -91,7 +91,7 @@ const ResourceForm = (): JSX.Element => {
   const requiredFields = ["url", "title", "source"];
   const isValid = isFormValid(formData, requiredFields);
 
-  const columns = [
+  const columns: Column<Resource>[] = [
     { header: "Title", accessor: "title" },
     { header: "URL", accessor: "url" },
     { header: "Source", accessor: "source" },


### PR DESCRIPTION
- Updated `ReusableTable` to support functional accessors and `keyof T` accessors for better typing.
- Updated `Course`, `Demo`, `Module`, `Resource`, and `Exercise` forms to use `Column<T>` with correct accessors
- Switched non-field accessors (e.g. `modules.length`, `resources.length`) to typed accessor functions.
