### PR TITLE
flowbite styling fix

### DIFF
--- a/codewit/client/tailwind.config.js
+++ b/codewit/client/tailwind.config.js
@@ -1,11 +1,12 @@
 /* v8 ignore next 98 */
 const { createGlobPatternsForDependencies } = require('@nx/react/tailwind');
-const { join } = require('path');
+const { join } = require("node:path");
 const flowbite = require("flowbite-react/tailwind");
+
+const root = join(__dirname, "../");
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  base: "",
   content: [
     join(
       __dirname,
@@ -15,8 +16,7 @@ module.exports = {
     join(__dirname, '../lib/shared/components/**/*.{ts,tsx}'),
     ...createGlobPatternsForDependencies(__dirname),
     './src/**/*.{js,jsx,ts,tsx}',
-    '../../node_modules/flowbite-react/lib/**/*.js',
-    './node_modules/flowbite/**/*.js',
+    flowbite.content({base: root}),
   ],
   theme: {
     screens: {
@@ -109,7 +109,6 @@ module.exports = {
   },
   plugins: [
     require('@tailwindcss/typography'),
-    require('flowbite/plugin'),
     require('daisyui'),
     flowbite.plugin(),
   ],


### PR DESCRIPTION
re-implemented fixes from a previous commit that got wipped out. specified where to find the root of the project and gave that to the `flowbite.content` function vs giving a relative path. still seems like the styling being found is finicky but we will see.