### PR TITLE
Standardize 4xx error handling and remove auto-redirects

### DIFF
--- a/codewit/client/src/app/app.tsx
+++ b/codewit/client/src/app/app.tsx
@@ -13,7 +13,7 @@ import ResourceForm from '../pages/ResourceForm';
 import CourseForm from '../pages/CourseForm';
 import DemoForms from '../pages/DemoForm';
 import UserManagement from '../pages/UserManagement';
-import Error from '../components/error/Error';
+import { ErrorPage } from '../components/error/Error';
 import LoadingPage from '../components/loading/LoadingPage';
 import TeacherView from '../pages/course/TeacherView';
 import DashboardGate from '../components/guards/DashboardGate';
@@ -113,7 +113,7 @@ export function App() {
                   to="/error"
                   state={{
                     message:
-                      'Oops! Page does not exist. We will return you to the main page.',
+                      'Oops! You do not have permission to access this page.\nPress the button below to return to the main page.',
                     statusCode: 401,
                   }}
                 />
@@ -130,7 +130,7 @@ export function App() {
                   to="/error"
                   state={{
                     message:
-                      'Oops! Page does not exist. We will return you to the main page.',
+                      'Oops! You do not have permission to access this page.\nPress the button below to return to the main page.',
                     statusCode: 401,
                   }}
                 />
@@ -152,7 +152,7 @@ export function App() {
               </DashboardGate>
             }
           />
-          <Route path="/error" element={<Error />} />
+          <Route path="/error" element={<ErrorPage />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </div>

--- a/codewit/client/src/components/error/Error.tsx
+++ b/codewit/client/src/components/error/Error.tsx
@@ -1,24 +1,17 @@
 // codewit/client/src/components/error/Error.tsx
-// Error.tsx
-import { Link, useLocation, useNavigate } from "react-router-dom";
-import { PropsWithChildren, ReactNode, useEffect } from "react";
+import { Link, useLocation } from "react-router-dom";
+import { PropsWithChildren, ReactNode } from "react";
 
 interface ErrorProps {
   message?: string;
   statusCode?: number; 
 }
 
-const Error = ({ message = "Oops! Page does not exist. We will return you to the main page.", statusCode = 400 }: ErrorProps): JSX.Element => {
+export const ErrorPage = ({ message = "Oops! Page does not exist. You can now return to the main page.", statusCode = 400 }: ErrorProps): JSX.Element => {
   const location = useLocation();
-  const navigate = useNavigate();
 
   const stateMessage = (location.state as { message?: string; statusCode?: number })?.message;
   const stateStatusCode = (location.state as { statusCode?: number })?.statusCode;
-
-  useEffect(() => {
-    const timer = setTimeout(() => navigate('/'), 5000);
-    return () => clearTimeout(timer);
-  }, [navigate]);
 
   const displayStatusCode = stateStatusCode || statusCode;
 
@@ -29,14 +22,20 @@ const Error = ({ message = "Oops! Page does not exist. We will return you to the
           {displayStatusCode} 
            <p className="ml-1 text-7xl font-bold tracking-tight text-white">Error</p>
         </h1>
-        <p className="text-lg">{stateMessage || message}</p>
+        <p className="text-lg whitespace-pre-line">{stateMessage || message}</p>
+        <div className="mt-6">
+          <Link to="/"
+            className="px-8 py-4 inline-flex items-center justify-center
+                       text-base font-semibold text-white bg-accent-500 rounded-lg
+                     hover:bg-accent-600 focus:ring-4 focus:ring-accent-300"
+          >
+            Back to home
+          </Link>
+        </div>
       </div>
-      <p className=" text-gray-400">Redirecting to the homepage in 5 seconds...</p>
     </div>
   );
 };
-
-export default Error;
 
 type ErrorViewProps = PropsWithChildren<{
   title?: string | ReactNode,

--- a/codewit/client/src/pages/CourseView.tsx
+++ b/codewit/client/src/pages/CourseView.tsx
@@ -5,7 +5,7 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 
 import { StudentCourse as StuCourse} from '@codewit/interfaces';
 
-import { default as ErrorView } from "../components/error/Error";
+import { ErrorPage } from "../components/error/Error";
 import Loading from "../components/loading/LoadingPage";
 import { useAxiosFetch } from "../hooks/fetching";
 
@@ -78,7 +78,7 @@ export default function CourseView({onCourseChange}: CourseView) {
   }
 
   if (error || course == null) {
-    return <ErrorView message="Failed to fetch courses. Please try again later."/>;
+    return <ErrorPage message="Failed to fetch courses. Please try again later."/>;
   }
 
   if (course.type === "TeacherView") {

--- a/codewit/client/src/pages/Home.tsx
+++ b/codewit/client/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '../hooks/useAuth';
-import Error from '../components/error/Error';
+import { ErrorPage } from '../components/error/Error';
 import Loading from '../components/loading/LoadingPage';
 import { DemoResponse } from '@codewit/interfaces';
 import { Accordion } from '@codewit/shared/components';
@@ -85,7 +85,7 @@ export default function Home() {
    }  
 
   if (error) {
-    return <Error message="Failed to fetch courses. Please try again later." />;
+    return <ErrorPage message="Failed to fetch courses. Please try again later." />;
   }
 
   if (data.student.length === 0 && data.instructor.length === 0) {

--- a/codewit/client/src/pages/course/TeacherView.tsx
+++ b/codewit/client/src/pages/course/TeacherView.tsx
@@ -4,7 +4,7 @@ import bulbLit from '/bulb(lit).svg';
 
 import { useCourseProgress } from '../../hooks/useCourse';
 import Loading  from '../../components/loading/LoadingPage';
-import { default as ErrorEle } from '../../components/error/Error';
+import { ErrorPage } from '../../components/error/Error';
 import { useAxiosFetch } from "../../hooks/fetching";
 import { useEffect, useState } from "react";
 import PendingRequestsCard from './components/PendingRequestsCard';
@@ -73,7 +73,7 @@ export default function TeacherView({ onCourseChange }: TeacherViewProps) {
   }
   
   if (error || course_error || course == null || !students) {
-    return <ErrorEle message="Failed to load course information"/>;
+    return <ErrorPage message="Failed to load course information"/>;
   }
 
   // persist both flags in one PATCH


### PR DESCRIPTION
## Summary

Previously, 4xx states were handled inconsistently:
- Some routes auto-redirected away after a delay.
- Others showed different error layouts or messages.
- The UX around "how do I get back to safety?" depended on where you were.

## Changes

- Updated `ErrorPage` in `client/src/components/error/Error.tsx`:
  - Removed the 5s auto-redirect behavior.
  - Added a prominent "Back to home" button styled as a primary action.
- Updated 4xx route handling in `client/src/app/app.tsx`

Closes #121