### PR TITLE
demo scroll fix #144

### DIFF
--- a/codewit/client/src/pages/Read.tsx
+++ b/codewit/client/src/pages/Read.tsx
@@ -336,7 +336,7 @@ interface RightPanelProps {
 function RightPanel({info, course_id}: RightPanelProps) {
   const navigate = useNavigate();
 
-  const container_ref = useRef(null);
+  const container_ref = useRef<HTMLDivElement>(null);
   const [exercise_index, set_exercise_index] = useState(0);
   const [last_attempt, set_last_attempt] = useState<AttemptWithEval | null>(null);
   const [submission_state, set_submission_state] = useState<SubmissionState>(SubmissionState.Submit);


### PR DESCRIPTION
this is a potential fix for more easily scrolling the demo markdown and code input. there is a sticky button when scrolling the prompt that will jump you down to the code input and another button that will jump you to the top of the prompt. the submit and reset buttons are also sticky relative to the code input.

It would be nice to have the editor not capture all scroll events and without looking more into how the editor works this will hopefully help to alleviate current UX.

not totally set on this so if there are issues or if someone has a better idea then we can give it a try.

closes #144