### PR TITLE
Enables C++ in production, fixes #147

### DIFF
--- a/codewit/docker-compose.yml
+++ b/codewit/docker-compose.yml
@@ -131,7 +131,7 @@ services:
       - PORT=3002
       - REDIS_HOST=redis
       - REDIS_PORT=6379
-      - ENABLE_CPP=false
+      - ENABLE_CPP=true
     ports:
       - 3002:3002
     networks:

--- a/codewit/k8s/codeeval-deployment.yaml
+++ b/codewit/k8s/codeeval-deployment.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - env:
             - name: ENABLE_CPP
-              value: "false"
+              value: "true"
             - name: HOST
               value: 0.0.0.0
             - name: PORT


### PR DESCRIPTION
This just updates the `ENABLE_CPP` environment variable to `true` for production. We previously disabled it to protect against fork bombs but now the QA team is ready to test C++ exercises since we have added guardrails against fork bombs.