### PR TITLE
Scope student module/demo completion to current user

### DIFF
--- a/codewit/api/src/controllers/course.ts
+++ b/codewit/api/src/controllers/course.ts
@@ -283,7 +283,11 @@ async function getStudentCoursesByUid(userUid: number): Promise<CourseResponse[]
   return formatCourseResponse(courses, true);
 }
 
-export async function getStudentCourse(course_id: string, transaction?: Transaction): Promise<StudentCourse | null> {
+export async function getStudentCourse(
+  course_id: string,
+  userUid: number,
+  transaction?: Transaction
+): Promise<StudentCourse | null> {
   const course = await Course.findOne({
     where: { id: course_id },
     include: [
@@ -295,9 +299,19 @@ export async function getStudentCourse(course_id: string, transaction?: Transact
           Resource,
           {
             association: "demos",
-            include: [ UserDemoCompletion ],
+            include: [
+              {
+                model: UserDemoCompletion,
+                where: { userUid },
+                required: false,
+              },
+            ],
           },
-          UserModuleCompletion,
+          {
+            model: UserModuleCompletion,
+            where: { userUid },
+            required: false,
+          },
         ],
         through: { attributes: ['ordering'] },
       },
@@ -323,7 +337,7 @@ export async function getStudentCourse(course_id: string, transaction?: Transact
 
       let completion = 0.0;
 
-      if (module_demo["UserDemoCompletions"]?.length ?? 0 != 0) {
+      if ((module_demo["UserDemoCompletions"]?.length ?? 0) !== 0) {
         completion = module_demo["UserDemoCompletions"][0].completion;
       }
 
@@ -348,7 +362,7 @@ export async function getStudentCourse(course_id: string, transaction?: Transact
 
     let completion = 0.0;
 
-    if (course_module["UserModuleCompletions"]?.length ?? 0 != 0) {
+    if ((course_module["UserModuleCompletions"]?.length ?? 0) !== 0) {
       completion = course_module["UserModuleCompletions"][0].completion;
     }
 

--- a/codewit/api/src/routes/course.ts
+++ b/codewit/api/src/routes/course.ts
@@ -252,7 +252,7 @@ courseRouter.get('/:uid', asyncHandle(async (req, res) => {
   let student_view = "student_view" in req.query && req.query["student_view"] === "1";
 
   if (student_and_instructor && student_view) {
-    let course = await getStudentCourse(req.params.uid);
+    let course = await getStudentCourse(req.params.uid, req.user.uid);
 
     if (course == null) {
       throw new Error("the course was not found when it was found?");
@@ -285,7 +285,7 @@ courseRouter.get('/:uid', asyncHandle(async (req, res) => {
       ...result,
     });
   } else if (found.is_student) {
-    let course = await getStudentCourse(req.params.uid);
+    let course = await getStudentCourse(req.params.uid, req.user.uid);
 
     if (course == null) {
       throw new Error("the course was not found when it was found?");
@@ -528,7 +528,7 @@ courseRouter.post("/:uid/register", asyncHandle(async (req, res) => {
           }
         );
 
-        let course = await getStudentCourse(req.params.uid, transaction);
+        let course = await getStudentCourse(req.params.uid, req.user.uid, transaction);
 
         if (course == null) {
           throw new Error("the course was not found when it was found?");


### PR DESCRIPTION
## Summary
Fixes a student-progress data leak in course student view.

When multiple students were in the same class, the student course query could read completion rows from another student (often the furthest-progressed student), causing incorrect module access/progress in the UI.

## Root Cause
`getStudentCourse` loaded:
- `UserDemoCompletion`
- `UserModuleCompletion`

without filtering by the authenticated student. The response logic then used the first completion row available, which could belong to a different user in the same class.

## Changes Made
- Updated `getStudentCourse(course_id, userUid, transaction?)` to require `userUid`.
- Added `where: { userUid }` filters to:
  - `UserDemoCompletion` include
  - `UserModuleCompletion` include
- Kept these includes `required: false` so modules/demos still return when no completion exists yet.
- Updated all `getStudentCourse` call sites to pass `req.user.uid`:
  - student view response path
  - student role path
  - auto-enroll registration path

## Verification
- `npx nx build api`
- `npx nx build api --skip-nx-cache`

Manual validation:
1. Enroll two students in same course.
2. Progress student A further than student B.
3. Load `GET /api/courses/<course_id>?student_view=1` as each user.
4. Confirm `modules[].completion` and unlocked module state are user-specific.

## Linked Issue
Closes #149 
