### PR TITLE
hide tanstack dev tools

### DIFF
--- a/codewit/client/src/main.tsx
+++ b/codewit/client/src/main.tsx
@@ -24,20 +24,24 @@ root.render(
       <App />
       <ToastContainer position="bottom-right" autoClose={1000} />
     </BrowserRouter>
-    <TanStackDevtools
-      plugins={[
-        {
-          name: "TanStack Query",
-          render: <ReactQueryDevtoolsPanel/>,
-          defaultOpen: true,
-        },
-        {
-          name: "TanStack Form",
-          render: <FormDevtoolsPanel/>,
-          defaultOpen: false,
-        },
-      ]}
-    />
+    {import.meta.env.DEV ?
+      <TanStackDevtools
+        plugins={[
+          {
+            name: "TanStack Query",
+            render: <ReactQueryDevtoolsPanel/>,
+            defaultOpen: true,
+          },
+          {
+            name: "TanStack Form",
+            render: <FormDevtoolsPanel/>,
+            defaultOpen: false,
+          },
+        ]}
+      />
+      :
+      null
+    }
   </QueryClientProvider>
   // </StrictMode>
 );


### PR DESCRIPTION
currently in production the tanstack dev tools button is visible on the main page eventhough the tools themselves are disabled. this will hide the button in non DEV builds of the client application.