### PR TITLE
Landing page open-enrollment redesign

### DIFF
--- a/codewit/api/src/main.ts
+++ b/codewit/api/src/main.ts
@@ -42,7 +42,13 @@ app.use('/demos', checkAuth, demoRouter);
 app.use('/exercises', checkAuth, exerciseRouter);
 app.use('/modules', checkAuth, moduleRouter);
 app.use('/resources', checkAuth, resourceRouter);
-app.use('/courses', checkAuth, courseRouter);
+app.use('/courses', (req, res, next) => {
+  if (req.path === '/landing' || req.path === '/landing/') {
+    return next();
+  }
+
+  return checkAuth(req, res, next);
+}, courseRouter);
 app.use('/attempts', checkAuth, attemptRouter);
 
 app.use(catchError);

--- a/codewit/api/src/routes/auth.ts
+++ b/codewit/api/src/routes/auth.ts
@@ -4,24 +4,53 @@ import { FRONTEND_URL } from '../secrets';
 
 const authRouter = Router();
 
+function sanitizeReturnTo(value: unknown): string | null {
+  if (typeof value !== 'string' || value.length === 0) {
+    return null;
+  }
+
+  if (!value.startsWith('/') || value.startsWith('//')) {
+    return null;
+  }
+
+  return value;
+}
+
+function resolveFrontendRedirect(returnTo?: string | null): string {
+  const frontendUrl = FRONTEND_URL ?? '/';
+
+  if (!returnTo) {
+    return frontendUrl;
+  }
+
+  try {
+    return new URL(returnTo, frontendUrl).toString();
+  } catch {
+    return frontendUrl;
+  }
+}
+
 authRouter.get(
   '/google',
-  passport.authenticate('google', {
-    scope: ['email', 'profile'],
-  }),
-  (req, res) => {
-    res.send(200);
+  (req, res, next) => {
+    const returnTo = sanitizeReturnTo(req.query.returnTo);
+
+    passport.authenticate('google', {
+      scope: ['email', 'profile'],
+      state: returnTo ?? undefined,
+    })(req, res, next);
   }
 );
 
 authRouter.get(
   '/google/redirect',
   passport.authenticate('google', {
-    failureRedirect: FRONTEND_URL,
+    failureRedirect: FRONTEND_URL ?? '/',
     session: true,
   }),
   (req, res) => {
-    res.redirect(FRONTEND_URL);
+    const returnTo = sanitizeReturnTo(req.query.state);
+    res.redirect(resolveFrontendRedirect(returnTo));
   }
 );
 
@@ -31,7 +60,7 @@ authRouter.get('/google/logout', (req, res) => {
       console.error(err);
     }
 
-    res.redirect(FRONTEND_URL);
+    res.redirect(FRONTEND_URL ?? '/');
   });
 });
 
@@ -48,7 +77,7 @@ authRouter.get('/google/userInfo', (req, res) => {
     });
   }
 
-  res.redirect('/oauth2/google');
+  res.status(401).json({ user: null });
 });
 
 export default authRouter;

--- a/codewit/api/src/routes/course.ts
+++ b/codewit/api/src/routes/course.ts
@@ -39,11 +39,23 @@ interface UserStatus {
   is_student: boolean,
 }
 
+interface OpenEnrollmentCourseRow {
+  id: string,
+  title: string,
+  language: string,
+  created_at: Date | string | null,
+  module_names: string[],
+  enrollment_count: number,
+  is_student: boolean,
+  is_instructor: boolean,
+  is_registered: boolean,
+}
+
 const courseRouter = Router();
 
 courseRouter.get("/landing", asyncHandle(async (req, res) => {
-  let [as_instructor, as_student] = await Promise.all([
-    Course.findAll({
+  let [as_instructor, as_student, open_enrollment] = await Promise.all([
+    req.user ? Course.findAll({
       include: [
         Language,
         {
@@ -53,8 +65,8 @@ courseRouter.get("/landing", asyncHandle(async (req, res) => {
           }
         },
       ]
-    }),
-    Course.findAll({
+    }) : Promise.resolve([]),
+    req.user ? Course.findAll({
       include: [
         Language,
         {
@@ -68,12 +80,59 @@ courseRouter.get("/landing", asyncHandle(async (req, res) => {
       order: [
         [ Course.associations.instructors, "username" ]
       ]
-    })
+    }) : Promise.resolve([]),
+    sequelize.query<OpenEnrollmentCourseRow>(
+      `
+      select
+        courses.id,
+        courses.title,
+        coalesce(languages.name::text, '') as language,
+        courses."createdAt" as created_at,
+        coalesce((
+          select array_agg(modules.topic order by cm.ordering)
+          from "CourseModules" cm
+          join modules on modules.uid = cm."moduleUid"
+          where cm."courseId" = courses.id
+        ), '{}'::text[]) as module_names,
+        coalesce((
+          select count(*)::int
+          from "CourseRoster" roster
+          where roster."courseId" = courses.id
+        ), 0)::int as enrollment_count,
+        exists(
+          select 1
+          from "CourseRoster" roster_self
+          where roster_self."courseId" = courses.id
+            and roster_self."userUid" = $1::int
+        ) as is_student,
+        exists(
+          select 1
+          from "CourseInstructors" instructor_self
+          where instructor_self."courseId" = courses.id
+            and instructor_self."userUid" = $1::int
+        ) as is_instructor,
+        exists(
+          select 1
+          from course_registrations registration_self
+          where registration_self."courseId" = courses.id
+            and registration_self."userUid" = $1::int
+        ) as is_registered
+      from courses
+        left join languages on languages.uid = courses."languageUid"
+      where courses.enrolling = true
+      order by enrollment_count desc, courses.title asc
+      `,
+      {
+        bind: [req.user?.uid ?? null],
+        type: QueryTypes.SELECT,
+      }
+    )
   ]);
 
   let rtn = {
     student: [],
     instructor: [],
+    openEnrollment: [],
   };
 
   for (let course of as_instructor) {
@@ -98,6 +157,22 @@ courseRouter.get("/landing", asyncHandle(async (req, res) => {
       title: course.title,
       language: course.language.name,
       instructors,
+    });
+  }
+
+  for (let course of open_enrollment) {
+    rtn.openEnrollment.push({
+      id: course.id,
+      title: course.title,
+      language: course.language,
+      createdAt: course.created_at instanceof Date
+        ? course.created_at.toISOString()
+        : course.created_at,
+      moduleNames: course.module_names,
+      enrollmentCount: course.enrollment_count,
+      isStudent: course.is_student,
+      isInstructor: course.is_instructor,
+      isRegistered: course.is_registered,
     });
   }
 

--- a/codewit/client/src/app/app.tsx
+++ b/codewit/client/src/app/app.tsx
@@ -18,6 +18,7 @@ import LoadingPage from '../components/loading/LoadingPage';
 import TeacherView from '../pages/course/TeacherView';
 import DashboardGate from '../components/guards/DashboardGate';
 import axios from 'axios';
+import { buildGoogleLoginHref } from '../utils/auth';
 
 const TOP_LEVEL = new Set(['', 'create', 'usermanagement', 'read', 'settings', 'login', 'error']);
 
@@ -28,6 +29,9 @@ export function App() {
 
   const isLandingPage = location.pathname === '/';
   const isUserManagement = location.pathname.startsWith('/usermanagement');
+  const loginHref = !user
+    ? buildGoogleLoginHref(`${location.pathname}${location.search}${location.hash}`)
+    : undefined;
 
   const [courseTitle, setCourseTitle] = useState<string>(() =>
      localStorage.getItem('courseTitle') || '',
@@ -91,12 +95,13 @@ export function App() {
         admin={user ? user.isAdmin : false}
         handleLogout={handleLogout}
         courseTitle={isLandingPage ? '' : courseTitle}
+        loginHref={loginHref}
       />
       <div className="relative flex-1 overflow-auto">
         <Routes>
           <Route
             path="/"
-            element={<Home />}
+            element={<Home user={user} />}
           />
           <Route
             path="/:course_id"

--- a/codewit/client/src/components/auth/LoginRequiredPrompt.tsx
+++ b/codewit/client/src/components/auth/LoginRequiredPrompt.tsx
@@ -1,6 +1,7 @@
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 
 import { CenterPrompt } from "../placeholders";
+import { buildGoogleLoginHref } from "../../utils/auth";
 
 interface LoginRequiredPromptProps {
   message?: string,
@@ -9,6 +10,11 @@ interface LoginRequiredPromptProps {
 export default function LoginRequiredPrompt({
   message = "To visit this page, you need to be logged in.",
 }: LoginRequiredPromptProps) {
+  const location = useLocation();
+  const loginHref = buildGoogleLoginHref(
+    `${location.pathname}${location.search}${location.hash}`
+  );
+
   return (
     <CenterPrompt header="Log in to proceed">
       <p className="mt-2 text-center text-white">
@@ -22,7 +28,7 @@ export default function LoginRequiredPrompt({
           Return Home
         </Link>
         <a
-          href="/api/oauth2/google"
+          href={loginHref}
           className="w-full rounded-md bg-accent-500 px-4 py-2 text-center text-white transition hover:bg-accent-600 sm:w-auto"
         >
           Log In

--- a/codewit/client/src/components/nav/Nav.tsx
+++ b/codewit/client/src/components/nav/Nav.tsx
@@ -4,6 +4,7 @@ import { Navbar, Button } from 'flowbite-react';
 import { Link, useSearchParams} from 'react-router-dom';
 import { ArrowLeftStartOnRectangleIcon, Bars3Icon, XMarkIcon } from '@heroicons/react/24/solid';
 import { UserCircleIcon, AcademicCapIcon } from '@heroicons/react/24/outline';
+import GoogleLogo from '../logo/GoogleLogo';
 
 const NavBar = ({
   name,
@@ -11,12 +12,14 @@ const NavBar = ({
   handleLogout,
   courseTitle,
   courseId,
+  loginHref,
 }: {
   name: string;
   admin: boolean;
   handleLogout: () => void;
   courseTitle?: string;
   courseId?: string;
+  loginHref?: string;
 }): JSX.Element => {
   const [isOpen, setIsOpen] = useState(false);
   const toggleNavbar = () => setIsOpen(!isOpen);
@@ -86,62 +89,74 @@ const NavBar = ({
             </div>
           )}
 
-          <button
-            ref={toggleRef}
-            data-testid="navbar-toggle"
-            className="h-9 px-3 relative flex items-center justify-center text-sm text-accent-600 hover:text-accent-700 bg-transparent dark:bg-transparent rounded-lg text-center font-medium focus:outline-none focus:ring-4"
-            onClick={toggleNavbar}
-          >
-            {isOpen ? <XMarkIcon className="h-6 w-6" /> : <Bars3Icon className="h-6 w-6" />}
-          </button>
+          {loginHref ? (
+            <a
+              href={loginHref}
+              className="inline-flex items-center gap-3 rounded-full bg-white px-4 py-2 text-sm font-semibold text-foreground-600 shadow-sm transition hover:bg-highlight-300"
+            >
+              <GoogleLogo className="h-5 w-5" />
+              <span>Log In with Google</span>
+            </a>
+          ) : (
+            <button
+              ref={toggleRef}
+              data-testid="navbar-toggle"
+              className="h-9 px-3 relative flex items-center justify-center text-sm text-accent-600 hover:text-accent-700 bg-transparent dark:bg-transparent rounded-lg text-center font-medium focus:outline-none focus:ring-4"
+              onClick={toggleNavbar}
+            >
+              {isOpen ? <XMarkIcon className="h-6 w-6" /> : <Bars3Icon className="h-6 w-6" />}
+            </button>
+          )}
         </div>
       </div>
 
-      <div
-        ref={drawerRef}
-        className={`fixed top-0 right-0 w-64 h-screen bg-foreground-700 shadow-lg z-50 flex flex-col transform transition-transform duration-300 ease-in-out ${
-          isOpen ? 'translate-x-0' : 'translate-x-full'
-        }`}
-      >
-        <div className="flex justify-end p-2">
-          <Button
-            size="sm"
-            className="text-accent-500 hover:text-accent-700 bg-transparent dark:bg-transparent"
-            color="dark"
-            onClick={closeNavbar}
-          >
-            <XMarkIcon className="h-6 w-6" />
-          </Button>
+      {!loginHref && (
+        <div
+          ref={drawerRef}
+          className={`fixed top-0 right-0 w-64 h-screen bg-foreground-700 shadow-lg z-50 flex flex-col transform transition-transform duration-300 ease-in-out ${
+            isOpen ? 'translate-x-0' : 'translate-x-full'
+          }`}
+        >
+          <div className="flex justify-end p-2">
+            <Button
+              size="sm"
+              className="text-accent-500 hover:text-accent-700 bg-transparent dark:bg-transparent"
+              color="dark"
+              onClick={closeNavbar}
+            >
+              <XMarkIcon className="h-6 w-6" />
+            </Button>
+          </div>
+          <div className="flex flex-col px-4 space-y-4">
+            <Link to="/" className="block px-3 p-1 rounded-md text-base font-medium text-accent-500 hover:text-white hover:bg-accent-600">
+              Home
+            </Link>
+            {admin && (
+              <>
+                <Link to="/create" className="block px-3 p-1 rounded-md text-base font-medium text-accent-500 hover:text-white hover:bg-accent-600">
+                  Create
+                </Link>
+                <Link to="/usermanagement" className="block px-3 p-1 rounded-md text-base font-medium text-accent-500 hover:text-white hover:bg-accent-600">
+                  Manage Users
+                </Link>
+              </>
+            )}
+            {name && (
+              <div className="flex flex-col items-center space-y-2">
+                <Button
+                  size="sm"
+                  color="failure"
+                  onClick={handleLogout}
+                  className="w-full bg-accent-500 text-white hover:bg-accent-600 rounded-lg py-2 px-4 flex items-center gap-3 shadow-md transition-all"
+                >
+                  <ArrowLeftStartOnRectangleIcon className="h-5 w-5 mr-1" />
+                  <span className="text-md font-medium">Logout</span>
+                </Button>
+              </div>
+            )}
+          </div>
         </div>
-        <div className="flex flex-col px-4 space-y-4">
-          <Link to="/" className="block px-3 p-1 rounded-md text-base font-medium text-accent-500 hover:text-white hover:bg-accent-600">
-            Home
-          </Link>
-          {admin && (
-            <>
-              <Link to="/create" className="block px-3 p-1 rounded-md text-base font-medium text-accent-500 hover:text-white hover:bg-accent-600">
-                Create
-              </Link>
-              <Link to="/usermanagement" className="block px-3 p-1 rounded-md text-base font-medium text-accent-500 hover:text-white hover:bg-accent-600">
-                Manage Users
-              </Link>
-            </>
-          )}
-          {name && (
-            <div className="flex flex-col items-center space-y-2">
-              <Button
-                size="sm"
-                color="failure"
-                onClick={handleLogout}
-                className="w-full bg-accent-500 text-white hover:bg-accent-600 rounded-lg py-2 px-4 flex items-center gap-3 shadow-md transition-all"
-              >
-                <ArrowLeftStartOnRectangleIcon className="h-5 w-5 mr-1" />
-                <span className="text-md font-medium">Logout</span>
-              </Button>
-            </div>
-          )}
-        </div>
-      </div>
+      )}
     </Navbar>
   );
 };

--- a/codewit/client/src/pages/CourseView.tsx
+++ b/codewit/client/src/pages/CourseView.tsx
@@ -1,7 +1,7 @@
 import axios, { AxiosError } from "axios";
 import { Modal } from "flowbite-react";
 import { useEffect, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
 
 import { StudentCourse as StuCourse} from '@codewit/interfaces';
 
@@ -61,7 +61,9 @@ interface CourseView {
 export default function CourseView({onCourseChange}: CourseView) {
   const { course_id } = useParams();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { user, loading: authLoading } = useAuth();
+  const autoJoin = searchParams.get('join') === '1';
 
   if (course_id == null) {
     throw new Error("course_id not provided");
@@ -78,6 +80,12 @@ export default function CourseView({onCourseChange}: CourseView) {
       onCourseChange(course.title);
     }
   }, [course, onCourseChange]);
+
+  useEffect(() => {
+    if (course?.type === "StudentView" && autoJoin) {
+      navigate(`/${course_id}`, { replace: true });
+    }
+  }, [autoJoin, course, course_id, navigate]);
 
   if (authLoading || loading) {
     return <Loading />;
@@ -115,7 +123,12 @@ export default function CourseView({onCourseChange}: CourseView) {
           course_id={course_id}
           course_title={course.title}
           auto_enroll={course.auto_enroll}
+          auto_join={autoJoin}
           on_update={data => {
+            if (autoJoin) {
+              navigate(`/${course_id}`, { replace: true });
+            }
+
             switch (data.type) {
               case "AlreadyEnrolled":
                 set_refresh(v => v + 1);
@@ -145,6 +158,7 @@ interface EnrollingViewProps {
   course_id: string,
   course_title: string,
   auto_enroll: boolean,
+  auto_join: boolean,
   on_update: (data: RegistrationResult) => void,
 }
 
@@ -153,10 +167,11 @@ interface RegError {
   message: string,
 }
 
-function EnrollingView({course_id, course_title, auto_enroll, on_update}: EnrollingViewProps) {
+function EnrollingView({course_id, course_title, auto_enroll, auto_join, on_update}: EnrollingViewProps) {
   const [sending, set_sending] = useState(false);
   const [reg_state, set_reg_state] = useState<RegistrationResult | null>(null);
   const [error, set_error] = useState<RegError | null>(null);
+  const [auto_requested, set_auto_requested] = useState(false);
 
   async function request_enrollment() {
     if (sending) {
@@ -214,6 +229,15 @@ function EnrollingView({course_id, course_title, auto_enroll, on_update}: Enroll
 
     set_sending(false);
   }
+
+  useEffect(() => {
+    if (!auto_join || auto_requested || sending || reg_state != null || error != null) {
+      return;
+    }
+
+    set_auto_requested(true);
+    void request_enrollment();
+  }, [auto_join, auto_requested, sending, reg_state, error]);
 
   let modal_title = null;
   let modal_contents = null;

--- a/codewit/client/src/pages/Home.tsx
+++ b/codewit/client/src/pages/Home.tsx
@@ -256,14 +256,14 @@ function OpenEnrollmentSection({
 
     {warning && <InlineWarning message={warning} />}
 
-    <div className={isGuest
-      ? "flex flex-col gap-3 border-b pb-2 sm:flex-row sm:items-end sm:justify-between"
-      : "flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end"
-    }>
-      <div className={isGuest
-        ? "flex flex-wrap items-center gap-5 px-1 text-accent-500"
-        : "flex flex-wrap items-center gap-5 text-accent-500 sm:order-2"
-      }>
+	    <div className={isGuest
+	      ? "flex flex-col gap-3 border-b pb-2 sm:flex-row sm:items-end sm:justify-between"
+	      : "flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+	    }>
+	      <div className={isGuest
+	        ? "flex flex-wrap items-center gap-5 px-1 text-accent-500"
+	        : "flex flex-wrap items-center gap-5 text-accent-500"
+	      }>
         <SortButton
           active={sortState.key === 'title'}
           onClick={() => onSelectSort('title')}
@@ -289,10 +289,10 @@ function OpenEnrollmentSection({
             : <ArrowDownIcon className="h-4 w-4" />}
         />
       </div>
-      <div className={isGuest ? "" : "sm:order-1"}>
-        <LanguageFilter
-          selectedLanguage={selectedLanguage}
-          languages={languages}
+	      <div>
+	        <LanguageFilter
+	          selectedLanguage={selectedLanguage}
+	          languages={languages}
           onChange={onSelectLanguage}
         />
       </div>

--- a/codewit/client/src/pages/Home.tsx
+++ b/codewit/client/src/pages/Home.tsx
@@ -1,42 +1,28 @@
-import { useState, useEffect } from 'react';
-import { useAuth } from '../hooks/useAuth';
-import { ErrorPage } from '../components/error/Error';
-import Loading from '../components/loading/LoadingPage';
-import { DemoResponse } from '@codewit/interfaces';
-import { Accordion } from '@codewit/shared/components';
+import { ChangeEvent, useState } from 'react';
+import { User } from '@codewit/interfaces';
 import {
-  PlayIcon,
-  ChevronRightIcon,
+  ArrowDownIcon,
+  ArrowUpIcon,
+  ArrowRightCircleIcon,
   ChevronDownIcon,
-} from '@heroicons/react/24/solid';
-import bulbLit from '/bulb(lit).svg';
-import bulbUnlit from '/bulb(unlit).svg';
-import { useAxiosFetch } from "../hooks/fetching";
+} from '@heroicons/react/24/outline';
 import { Link } from "react-router-dom";
 
-const EmptyState = () => (
-  <div className="flex flex-col items-center justify-center py-20">
-    <h2 className="text-xl font-bold text-white mb-4">No Courses Available</h2>
-    <p className="text-zinc-400">
-      Please check back later for available courses.
-    </p>
-  </div>
-);
+import Loading from '../components/loading/LoadingPage';
+import { useAxiosFetch } from "../hooks/fetching";
+import { buildGoogleLoginHref } from "../utils/auth";
 
-const UnauthorizedState = () => (
-  <div className="h-2/3 flex flex-col items-center justify-center">
-    <h2 className="text-xl font-bold text-white mb-4">Please Sign In</h2>
-    <p className="text-zinc-400">Sign in to access your courses</p>
-    <a href="/api/oauth2/google">
-      <button
-        type="button"
-        className="mt-4 px-5 py-2.5 flex items-center text-sm font-medium text-white bg-accent-500 rounded-lg hover:bg-accent-600 focus:ring-4 focus:ring-accent-300"
-      >
-        Log In
-      </button>
-    </a>
-  </div>
-);
+const TEACHER_ACCOUNT_FORM_URL = 'https://forms.gle/TFJP5Uc746LUs3Vz8';
+const SECTION_ICON_SRC = '/bulb(lit).svg';
+const COURSE_CARD_CLASS = 'rounded-2xl bg-foreground-500 p-4 text-white';
+
+type SortKey = 'title' | 'newest';
+type SortDirection = 'asc' | 'desc';
+
+interface SortState {
+  key: SortKey,
+  direction: SortDirection,
+}
 
 interface InstructorPartial {
   uid: string,
@@ -57,58 +43,412 @@ interface StudentCoursePartial {
   instructors: InstructorPartial[],
 }
 
+interface OpenEnrollmentCourse {
+  id: string,
+  title: string,
+  language: string,
+  createdAt: string | null,
+  moduleNames: string[],
+  enrollmentCount: number,
+  isStudent: boolean,
+  isInstructor: boolean,
+  isRegistered: boolean,
+}
+
 interface Landing {
   student: StudentCoursePartial[],
   instructor: InstructorCoursePartial[],
+  openEnrollment: OpenEnrollmentCourse[],
 }
 
-export default function Home() {
+interface HomeProps {
+  user: User | null,
+}
+
+export default function Home({ user }: HomeProps) {
   const { data, loading, error } = useAxiosFetch<Landing>(
     "api/courses/landing",
     {
       student: [],
       instructor: [],
+      openEnrollment: [],
     },
   );
-  const { user, loading: user_loading } = useAuth();
+  const [selectedLanguage, setSelectedLanguage] = useState('all');
+  const [sortState, setSortState] = useState<SortState>({
+    key: 'title',
+    direction: 'asc',
+  });
 
-  if (user_loading) {
-     return <Loading />;
-   }
- 
-   if (!user) {
-     return <UnauthorizedState />;
-   }
- 
-   if (loading) {
-     return <Loading />;
-   }  
-
-  if (error) {
-    return <ErrorPage message="Failed to fetch courses. Please try again later." />;
+  if (loading) {
+    return <Loading />;
   }
 
-  if (data.student.length === 0 && data.instructor.length === 0) {
-    return <EmptyState />;
+  const hasValidLandingData = isLandingResponse(data);
+
+  if (!hasValidLandingData) {
+    console.error('Invalid landing response payload:', data);
   }
 
-  let instructor_list = null;
-  let student_list = null;
+  const landingData: Landing = hasValidLandingData ? data : {
+    student: [],
+    instructor: [],
+    openEnrollment: [],
+  };
 
-  if (data.instructor.length > 0) {
-    instructor_list = <InstructorCourseList courses={data.instructor}/>;
+  const landingWarning = error
+    ? 'Courses are temporarily unavailable because the API is failing right now.'
+    : hasValidLandingData
+      ? null
+      : 'Courses are temporarily unavailable because the landing data was not returned in the expected format.';
+
+  const languageOptions = ['all'];
+  for (const course of landingData.openEnrollment) {
+    if (!languageOptions.includes(course.language)) {
+      languageOptions.push(course.language);
+    }
   }
+  languageOptions.sort((left, right) => {
+    if (left === 'all') {
+      return -1;
+    }
 
-  if (data.student.length > 0) {
-    student_list = <StudentCourseList courses={data.student}/>;
-  }
+    if (right === 'all') {
+      return 1;
+    }
 
-  return <div className="h-full max-w-full bg-zinc-900">
-    <div className="max-w-7xl mx-auto px-10 py-4 space-y-2">
-      {instructor_list}
-      {student_list}
+    return formatLanguage(left).localeCompare(formatLanguage(right));
+  });
+
+  const filteredOpenEnrollment = landingData.openEnrollment.filter(course => (
+    selectedLanguage === 'all' || course.language === selectedLanguage
+  ));
+
+  const sortedOpenEnrollment = sortOpenEnrollmentCourses(filteredOpenEnrollment, sortState);
+
+  return <div className="h-full max-w-full overflow-auto bg-zinc-900 text-white">
+    <div className={user
+      ? "max-w-7xl mx-auto px-10 py-4 space-y-2"
+      : "max-w-7xl mx-auto min-h-full px-10 py-4 flex flex-col gap-2"
+    }>
+      {!user && <GuestLandingHeader />}
+
+      {user && (
+        <>
+          <HomeSection title="Instructing">
+            <InstructorCourseList courses={landingData.instructor} />
+          </HomeSection>
+          <HomeSection title="Attending">
+            <StudentCourseList courses={landingData.student} />
+          </HomeSection>
+        </>
+      )}
+
+      <OpenEnrollmentSection
+        variant={user ? 'home' : 'guest'}
+        courses={sortedOpenEnrollment}
+        allCourses={landingData.openEnrollment}
+        user={user}
+        selectedLanguage={selectedLanguage}
+        sortState={sortState}
+        warning={landingWarning}
+        onSelectLanguage={(event) => setSelectedLanguage(event.target.value)}
+        onSelectSort={(nextKey) => setSortState(current => {
+          if (current.key === nextKey) {
+            return {
+              key: nextKey,
+              direction: current.direction === 'asc' ? 'desc' : 'asc',
+            };
+          }
+
+          return {
+            key: nextKey,
+            direction: nextKey === 'title' ? 'asc' : 'desc',
+          };
+        })}
+        languages={languageOptions}
+      />
     </div>
   </div>;
+}
+
+function GuestLandingHeader() {
+  return <>
+    <section className="rounded-sm bg-alternate-background-500 px-6 py-5 text-center">
+      <h1 className="text-[1.5rem] font-bold leading-snug text-accent-500 sm:text-[1.65rem]">
+        Learn to code, from <span className="underline decoration-accent-400 decoration-2 underline-offset-4">students&apos;</span> unique perspectives
+      </h1>
+    </section>
+    <section className="rounded-sm bg-alternate-background-500 px-6 py-4">
+      <div className="flex items-start gap-3">
+        <SectionIcon className="mt-0.5 h-6 w-6 shrink-0" />
+        <p className="text-[1.02rem] font-semibold leading-7 text-white">
+          Teachers:{' '}
+          <a
+            href={TEACHER_ACCOUNT_FORM_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="text-accent-500 underline underline-offset-4 transition hover:text-accent-300"
+          >
+            request a free teacher account
+          </a>
+          <span className="font-normal text-foreground-100"> to manage your own, private class</span>
+        </p>
+      </div>
+    </section>
+  </>;
+}
+
+function HomeSection({
+  title,
+  children,
+}: {
+  title: string,
+  children: JSX.Element,
+}) {
+  return <section className="space-y-2">
+    <h2 className="border-b pb-2 text-xl text-foreground-200">
+      {title}
+    </h2>
+    {children}
+  </section>;
+}
+
+interface OpenEnrollmentSectionProps {
+  variant: 'guest' | 'home',
+  courses: OpenEnrollmentCourse[],
+  allCourses: OpenEnrollmentCourse[],
+  user: User | null,
+  selectedLanguage: string,
+  sortState: SortState,
+  warning: string | null,
+  onSelectLanguage: (event: ChangeEvent<HTMLSelectElement>) => void,
+  onSelectSort: (nextKey: SortKey) => void,
+  languages: string[],
+}
+
+function OpenEnrollmentSection({
+  variant,
+  courses,
+  allCourses,
+  user,
+  selectedLanguage,
+  sortState,
+  warning,
+  onSelectLanguage,
+  onSelectSort,
+  languages,
+}: OpenEnrollmentSectionProps) {
+  const isGuest = variant === 'guest';
+
+  return <section className={isGuest
+    ? "flex flex-1 flex-col gap-2 rounded-sm bg-alternate-background-500 px-4 py-4 pb-6 sm:px-5"
+    : "space-y-2"
+  }>
+    <div className={isGuest ? "" : "border-b pb-2"}>
+      <div className="flex items-center gap-3">
+        <SectionIcon className="h-6 w-6 shrink-0" />
+        <h2 className="text-xl text-foreground-200">
+          Join open-enrollment courses
+        </h2>
+      </div>
+    </div>
+
+    {warning && <InlineWarning message={warning} />}
+
+    <div className={isGuest
+      ? "flex flex-col gap-3 border-b pb-2 sm:flex-row sm:items-end sm:justify-between"
+      : "flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end"
+    }>
+      <div className={isGuest
+        ? "flex flex-wrap items-center gap-5 px-1 text-accent-500"
+        : "flex flex-wrap items-center gap-5 text-accent-500 sm:order-2"
+      }>
+        <SortButton
+          active={sortState.key === 'title'}
+          onClick={() => onSelectSort('title')}
+          label="Title"
+          icon={
+            <>
+              {sortState.key === 'title' && sortState.direction === 'desc'
+                ? <ArrowUpIcon className="h-4 w-4" />
+                : <ArrowDownIcon className="h-4 w-4" />}
+              <span className="flex flex-col text-[10px] font-bold leading-[0.55rem]">
+                <span>{sortState.key === 'title' && sortState.direction === 'desc' ? 'Z' : 'A'}</span>
+                <span>{sortState.key === 'title' && sortState.direction === 'desc' ? 'A' : 'Z'}</span>
+              </span>
+            </>
+          }
+        />
+        <SortButton
+          active={sortState.key === 'newest'}
+          onClick={() => onSelectSort('newest')}
+          label="Newest"
+          icon={sortState.key === 'newest' && sortState.direction === 'asc'
+            ? <ArrowUpIcon className="h-4 w-4" />
+            : <ArrowDownIcon className="h-4 w-4" />}
+        />
+      </div>
+      <div className={isGuest ? "" : "sm:order-1"}>
+        <LanguageFilter
+          selectedLanguage={selectedLanguage}
+          languages={languages}
+          onChange={onSelectLanguage}
+        />
+      </div>
+    </div>
+
+    <div className={isGuest ? "flex-1" : ""}>
+      <OpenEnrollmentCourseList
+        courses={courses}
+        user={user}
+        showEmptyState={allCourses.length === 0}
+        selectedLanguage={selectedLanguage}
+      />
+    </div>
+  </section>;
+}
+
+function SectionIcon({ className = "h-5 w-5" }: { className?: string }) {
+  return <img src={SECTION_ICON_SRC} alt="" aria-hidden="true" className={className} />;
+}
+
+function SortButton({
+  active,
+  label,
+  icon,
+  onClick,
+}: {
+  active: boolean,
+  label: string,
+  icon: JSX.Element,
+  onClick: () => void,
+}) {
+  return <button
+    type="button"
+    onClick={onClick}
+    className={[
+      "inline-flex items-center gap-1.5 text-sm font-semibold transition",
+      active ? "text-accent-300 underline underline-offset-4" : "text-accent-500 hover:text-accent-300",
+    ].join(' ')}
+  >
+    <span>{label}</span>
+    {icon}
+  </button>;
+}
+
+interface LanguageFilterProps {
+  selectedLanguage: string,
+  languages: string[],
+  onChange: (event: ChangeEvent<HTMLSelectElement>) => void,
+}
+
+function LanguageFilter({ selectedLanguage, languages, onChange }: LanguageFilterProps) {
+  return <label className="relative inline-flex items-center self-start sm:self-auto">
+    <span className="sr-only">Filter courses by language</span>
+    <select
+      value={selectedLanguage}
+      onChange={onChange}
+      className="min-w-[13rem] appearance-none rounded-md border border-accent-500 bg-foreground-500 px-4 py-2 pr-10 text-sm font-semibold text-accent-500 outline-none transition focus:ring-2 focus:ring-accent-500/30"
+    >
+      {languages.map(language => (
+        <option key={language} value={language}>
+          {language === 'all' ? 'All Languages' : formatLanguage(language)}
+        </option>
+      ))}
+    </select>
+    <ChevronDownIcon className="pointer-events-none absolute right-3 h-4 w-4 text-accent-300" />
+  </label>;
+}
+
+interface OpenEnrollmentCourseListProps {
+  courses: OpenEnrollmentCourse[],
+  user: User | null,
+  showEmptyState: boolean,
+  selectedLanguage: string,
+}
+
+function OpenEnrollmentCourseList({
+  courses,
+  user,
+  showEmptyState,
+  selectedLanguage,
+}: OpenEnrollmentCourseListProps) {
+  if (showEmptyState) {
+    return <EmptyMessage message="No open-enrollment courses are available right now." />;
+  }
+
+  if (courses.length === 0) {
+    return <EmptyMessage message={`No open-enrollment courses match ${formatLanguage(selectedLanguage)}.`} />;
+  }
+
+  return <div className="space-y-2">
+    {courses.map(course => (
+      <OpenEnrollmentCard
+        key={course.id}
+        course={course}
+        user={user}
+      />
+    ))}
+  </div>;
+}
+
+function OpenEnrollmentCard({
+  course,
+  user,
+}: {
+  course: OpenEnrollmentCourse,
+  user: User | null,
+}) {
+  const action = getOpenEnrollmentAction(course, user);
+
+  return <article className={COURSE_CARD_CLASS}>
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-4">
+      <div className="sm:w-[112px] sm:flex-none">
+        <ActionButton action={action} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <h3 className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-base leading-6">
+          <span className="font-bold text-white">{course.title}</span>
+          <span className="text-foreground-100">- {formatLanguage(course.language)}</span>
+        </h3>
+        <p className="mt-1 text-[0.98rem] leading-6 text-foreground-100">
+          {course.moduleNames.length === 0 ? 'No modules added yet.' : course.moduleNames.join(', ')}
+        </p>
+      </div>
+    </div>
+  </article>;
+}
+
+interface ActionDescriptor {
+  label: string,
+  href?: string,
+  disabled?: boolean,
+  external?: boolean,
+}
+
+function ActionButton({ action }: { action: ActionDescriptor }) {
+  const className = [
+    "inline-flex w-full items-center justify-center gap-2 rounded-md border px-3 py-1.5 text-sm font-bold transition",
+    action.disabled
+      ? "cursor-not-allowed border-foreground-300/30 bg-foreground-600 text-foreground-200"
+      : "border-accent-500 bg-transparent text-accent-500 hover:bg-accent-500/10",
+  ].join(' ');
+
+  const content = <>
+    <ArrowRightCircleIcon className="h-5 w-5 shrink-0" />
+    <span>{action.label}</span>
+  </>;
+
+  if (action.disabled || !action.href) {
+    return <span className={className}>{content}</span>;
+  }
+
+  if (action.external) {
+    return <a href={action.href} className={className}>{content}</a>;
+  }
+
+  return <Link to={action.href} className={className}>{content}</Link>;
 }
 
 interface StudentCourseListProps {
@@ -116,57 +456,162 @@ interface StudentCourseListProps {
 }
 
 function StudentCourseList({ courses }: StudentCourseListProps) {
-  return <div className="space-y-2">
-    <h2 className="border-b text-2xl pb-2">Attending</h2>
-    {courses.map(course => {
-      return <div key={course.id} className="p-4 rounded-2xl bg-foreground-500 text-white">
-        <h3 className="text-xl">
+  if (courses.length === 0) {
+    return <EmptyMessage message="You are not attending any courses yet." />;
+  }
+
+  return <div className="space-y-3">
+    {courses.map(course => (
+      <article key={course.id} className={COURSE_CARD_CLASS}>
+        <h3 className="text-lg font-semibold">
           <Link to={`/${course.id}`}>
             {course.title}
           </Link>
         </h3>
-        <span>language: {course.language}</span>
-        <div className="flex flex-row gap-x-2">
-          <span>instructors:</span>
-          <>
-            {course.instructors.length === 0 ?
-              <span>No instructors for this course</span>
-              :
-              course.instructors.map((instructor, index) => {
-                if (index === course.instructors.length - 1) {
-                  return <span key={instructor.uid}>
-                    {instructor.username}
-                  </span>
-                } else {
-                  return <span key={instructor.uid}>
-                    {instructor.username},
-                  </span>
-                }
-              })
-            }
-          </>
-        </div>
-      </div>;
-    })}
+        <p className="mt-2 text-sm text-foreground-100">
+          language: {formatLanguage(course.language)}
+        </p>
+        <p className="mt-1 text-sm text-foreground-100">
+          instructors: {formatInstructorNames(course.instructors)}
+        </p>
+      </article>
+    ))}
   </div>;
 }
 
 interface InstructorCourseListProps {
-  courses: InstructorCoursePartial[];
+  courses: InstructorCoursePartial[],
 }
 
 function InstructorCourseList({ courses }: InstructorCourseListProps) {
-  return <div className="space-y-2">
-    <h2 className="border-b text-2xl pb-2">Instructing</h2>
-    {courses.map(course => {
-      return <div key={course.id} className="p-4 rounded-2xl bg-foreground-500 text-white">
-        <h3 className="text-xl">
+  if (courses.length === 0) {
+    return <EmptyMessage message="You are not instructing any courses yet." />;
+  }
+
+  return <div className="space-y-3">
+    {courses.map(course => (
+      <article key={course.id} className={COURSE_CARD_CLASS}>
+        <h3 className="text-lg font-semibold">
           <Link to={`/${course.id}/dashboard`}>
             {course.title}
           </Link>
         </h3>
-        <span>language: {course.language}</span>
-      </div>;
-    })}
+        <p className="mt-2 text-sm text-foreground-100">
+          language: {formatLanguage(course.language)}
+        </p>
+      </article>
+    ))}
   </div>;
+}
+
+function EmptyMessage({ message }: { message: string }) {
+  return <div className="rounded-2xl bg-foreground-500 px-4 py-4 text-sm text-foreground-100">
+    {message}
+  </div>;
+}
+
+function InlineWarning({ message }: { message: string }) {
+  return <div className="rounded-2xl border border-amber-400/40 bg-foreground-500 px-4 py-3 text-sm text-amber-100">
+    {message}
+  </div>;
+}
+
+function sortOpenEnrollmentCourses(
+  courses: OpenEnrollmentCourse[],
+  sortState: SortState,
+): OpenEnrollmentCourse[] {
+  const sortedCourses = [...courses];
+
+  if (sortState.key === 'title') {
+    sortedCourses.sort((left, right) => {
+      const comparison = left.title.localeCompare(right.title);
+      return sortState.direction === 'asc' ? comparison : (comparison * -1);
+    });
+    return sortedCourses;
+  }
+
+  sortedCourses.sort((left, right) => {
+    const leftDate = left.createdAt == null ? 0 : Date.parse(left.createdAt);
+    const rightDate = right.createdAt == null ? 0 : Date.parse(right.createdAt);
+    const comparison = rightDate - leftDate;
+
+    if (comparison !== 0) {
+      return sortState.direction === 'desc' ? comparison : (comparison * -1);
+    }
+
+    return left.title.localeCompare(right.title);
+  });
+
+  return sortedCourses;
+}
+
+function formatLanguage(language: string): string {
+  switch (language) {
+    case 'cpp':
+      return 'C++';
+    case 'java':
+      return 'Java';
+    case 'python':
+      return 'Python';
+    case 'all':
+      return 'All Languages';
+    default:
+      return language;
+  }
+}
+
+function formatInstructorNames(instructors: InstructorPartial[]): string {
+  if (instructors.length === 0) {
+    return 'No instructors for this course';
+  }
+
+  return instructors.map(instructor => instructor.username).join(', ');
+}
+
+function getOpenEnrollmentAction(course: OpenEnrollmentCourse, user: User | null): ActionDescriptor {
+  if (user == null) {
+    return {
+      label: 'Join',
+      href: buildGoogleLoginHref(`/${course.id}?join=1`),
+      external: true,
+    };
+  }
+
+  if (course.isStudent) {
+    return {
+      label: 'Open',
+      href: `/${course.id}`,
+    };
+  }
+
+  if (course.isInstructor) {
+    return {
+      label: 'Dashboard',
+      href: `/${course.id}/dashboard`,
+    };
+  }
+
+  if (course.isRegistered) {
+    return {
+      label: 'Pending',
+      disabled: true,
+    };
+  }
+
+  return {
+    label: 'Join',
+    href: `/${course.id}?join=1`,
+  };
+}
+
+function isLandingResponse(value: unknown): value is Landing {
+  if (typeof value !== 'object' || value == null) {
+    return false;
+  }
+
+  const candidate = value as Partial<Landing>;
+
+  return Array.isArray(candidate.student) &&
+    Array.isArray(candidate.instructor) &&
+    Array.isArray(candidate.openEnrollment);
 }

--- a/codewit/client/src/pages/Home.tsx
+++ b/codewit/client/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, PropsWithChildren, useState } from 'react';
 import { User } from '@codewit/interfaces';
 import {
   ArrowDownIcon,
@@ -131,9 +131,7 @@ export default function Home({ user }: HomeProps) {
       ? "max-w-7xl mx-auto px-10 py-4 space-y-2"
       : "max-w-7xl mx-auto min-h-full px-10 py-4 flex flex-col gap-2"
     }>
-      {!user && <GuestLandingHeader />}
-
-      {user && (
+      {user ? (
         <>
           <HomeSection title="Instructing">
             <InstructorCourseList courses={landingData.instructor} />
@@ -142,6 +140,8 @@ export default function Home({ user }: HomeProps) {
             <StudentCourseList courses={landingData.student} />
           </HomeSection>
         </>
+      ) : (
+        <GuestLandingHeader />
       )}
 
       <OpenEnrollmentSection
@@ -202,10 +202,7 @@ function GuestLandingHeader() {
 function HomeSection({
   title,
   children,
-}: {
-  title: string,
-  children: JSX.Element,
-}) {
+}: PropsWithChildren<{ title: string }>) {
   return <section className="space-y-2">
     <h2 className="border-b pb-2 text-xl text-foreground-200">
       {title}

--- a/codewit/client/src/utils/auth.ts
+++ b/codewit/client/src/utils/auth.ts
@@ -1,0 +1,22 @@
+function normalizeReturnTo(returnTo?: string): string {
+  if (!returnTo || returnTo.trim().length === 0) {
+    return '/';
+  }
+
+  if (!returnTo.startsWith('/') || returnTo.startsWith('//')) {
+    return '/';
+  }
+
+  return returnTo;
+}
+
+export function buildGoogleLoginHref(returnTo?: string): string {
+  const normalized = normalizeReturnTo(returnTo);
+
+  if (normalized === '/') {
+    return '/api/oauth2/google';
+  }
+
+  const params = new URLSearchParams({ returnTo: normalized });
+  return `/api/oauth2/google?${params.toString()}`;
+}

--- a/codewit/client/vite.config.ts
+++ b/codewit/client/vite.config.ts
@@ -6,16 +6,15 @@ import dotenv from 'dotenv';
 
 dotenv.config({ path: '../../.env' });
 
-const API_PORT = process.env.API_PORT
-const API_HOST = process.env.API_HOST
-if (!API_HOST) {
-  console.log('BACKEND_URL is not set');
-}
-
-// const BACKEND_URL = `http://${API_HOST}:${API_PORT}/api`;
-// if API_HOST is not set, use http://app:3000
-
-const BACKEND_URL = API_HOST ? `http://${API_HOST}/` : 'http://app:3000/api';
+const API_PORT = process.env.API_PORT;
+const API_HOST = process.env.API_HOST;
+const API_TARGET = API_HOST
+  ? `http://${API_HOST}${API_PORT ? `:${API_PORT}` : ''}`
+  : 'http://localhost:3000';
+const CODEEVAL_TARGET = API_HOST
+  ? `http://${API_HOST}${API_PORT ? `:${API_PORT}` : ''}`
+  : 'http://localhost:3002';
+const usingGatewayProxy = Boolean(API_HOST);
 
 export default defineConfig(({ mode }) => ({
   root: __dirname,
@@ -36,6 +35,7 @@ export default defineConfig(({ mode }) => ({
   plugins: [react(), nxViteTsPaths()],
   server: {
     host: true,
+    port: 3001,
     allowedHosts: [
       'nginx',
       'localhost',
@@ -43,6 +43,18 @@ export default defineConfig(({ mode }) => ({
       'codewit.us',
       'codewit.dev',
     ],
+    proxy: {
+      '/api': {
+        target: API_TARGET,
+        changeOrigin: true,
+        rewrite: usingGatewayProxy ? undefined : (path) => path.replace(/^\/api/, ''),
+      },
+      '/codeeval': {
+        target: CODEEVAL_TARGET,
+        changeOrigin: true,
+        rewrite: usingGatewayProxy ? undefined : (path) => path.replace(/^\/codeeval/, ''),
+      },
+    },
   },
 
   // Uncomment this if you are using workers.


### PR DESCRIPTION
## Summary
- updates the logged-out landing page to match the new Figma layout
- adds the teacher account CTA linking to the Google Form in a new tab
- adds the `Join open-enrollment courses` section to both logged-out and logged-in home views
- shows all open-enrollment courses with course title, language, and ordered module names
- adds language filtering and title/newest sorting for open-enrollment courses
- preserves join intent through login and sends users into the student course view after joining
- allows the landing-page data route to be accessed without authentication

Closes #157